### PR TITLE
docs: Add codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # kickstart.go
-[![.github/workflows/build.yaml](https://github.com/raeperd/kickstart.go/actions/workflows/build.yaml/badge.svg)](https://github.com/raeperd/kickstart.go/actions/workflows/build.yaml) [![Go Report Card](https://goreportcard.com/badge/github.com/raeperd/kickstart.go)](https://goreportcard.com/report/github.com/raeperd/kickstart.go)  
+[![.github/workflows/build.yaml](https://github.com/raeperd/kickstart.go/actions/workflows/build.yaml/badge.svg)](https://github.com/raeperd/kickstart.go/actions/workflows/build.yaml) [![Go Report Card](https://goreportcard.com/badge/github.com/raeperd/kickstart.go)](https://goreportcard.com/report/github.com/raeperd/kickstart.go) [![codecov](https://codecov.io/gh/raeperd/kickstart.go/graph/badge.svg?token=T6jgDZXKVQ)](https://codecov.io/gh/raeperd/kickstart.go)   
 Minimalistic http server template in go that is:
 - Small (less than 300 lines of code)
 - Single file 


### PR DESCRIPTION
Add codecov results in docs.
But try not to add github action with codecov. since user might not want to configure codecov.
Used codecov cli to upload coverage.txt 