### PR TITLE
refactor: improve `Dockerfile` build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ ARG VERSION=local
 
 WORKDIR /src
 
-# this will cache if the go.mod and go.sum files are not changed
 COPY ./go.mod ./go.sum ./
 COPY ./Makefile .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,17 +4,17 @@ ARG VERSION=local
 WORKDIR /src
 
 # this will cache if the go.mod and go.sum files are not changed
-COPY ./go.mod /src
-COPY ./go.sum /src
-COPY ./Makefile /src
+COPY ./go.mod .
+COPY ./go.sum .
+COPY ./Makefile .
 
 RUN make download
 
-COPY . /src
+COPY . .
 
 RUN make build TARGET_EXEC=app CGO_ENABLED=0 VERSION=${VERSION}
 
-FROM scratch 
+FROM gcr.io/distroless/static-debian12
 
 COPY --from=builder /src/app /bin/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,22 @@ FROM golang:1.22-bullseye as builder
 ARG VERSION=local
 
 WORKDIR /src
-COPY . /src
+
+# this will cache if the go.mod and go.sum files are not changed
+COPY ./go.mod /src
+COPY ./go.sum /src
+COPY ./Makefile /src
+
 RUN make download
+
+COPY . /src
+
 RUN make build TARGET_EXEC=app CGO_ENABLED=0 VERSION=${VERSION}
 
-FROM gcr.io/distroless/static-debian12
+FROM scratch 
+
 COPY --from=builder /src/app /bin/app
+
+EXPOSE 8080
 ENTRYPOINT ["app"]
 CMD ["--port=8080"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ ARG VERSION=local
 WORKDIR /src
 
 # this will cache if the go.mod and go.sum files are not changed
-COPY ./go.mod .
-COPY ./go.sum .
+COPY ./go.mod ./go.sum ./
 COPY ./Makefile .
 
 RUN make download


### PR DESCRIPTION
This improvement does several things:

1. cache downloading go modules, if anything fails during build, the dependencies are cached
2. use scratch (2MB lower)
3. use expose 8080 (for docker desktop to show that it's used by default)