### PR TITLE
ci: Update coverage reports with coverall

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,9 @@ jobs:
           git diff --exit-code go.mod go.sum
       - run: make build VERSION=${{ github.ref_name }}
       - run: make test
+      - uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: coverage.txt
       - run: make docker VERSION=${{ github.ref_name }}
       - run: make clean
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # kickstart.go
-[![.github/workflows/build.yaml](https://github.com/raeperd/kickstart.go/actions/workflows/build.yaml/badge.svg)](https://github.com/raeperd/kickstart.go/actions/workflows/build.yaml) [![Go Report Card](https://goreportcard.com/badge/github.com/raeperd/kickstart.go)](https://goreportcard.com/report/github.com/raeperd/kickstart.go) [![codecov](https://codecov.io/gh/raeperd/kickstart.go/graph/badge.svg?token=T6jgDZXKVQ)](https://codecov.io/gh/raeperd/kickstart.go)   
+[![.github/workflows/build.yaml](https://github.com/raeperd/kickstart.go/actions/workflows/build.yaml/badge.svg)](https://github.com/raeperd/kickstart.go/actions/workflows/build.yaml) [![Go Report Card](https://goreportcard.com/badge/github.com/raeperd/kickstart.go)](https://goreportcard.com/report/github.com/raeperd/kickstart.go) [![Coverage Status](https://coveralls.io/repos/github/raeperd/kickstart.go/badge.svg?branch=ci-coverall)](https://coveralls.io/github/raeperd/kickstart.go?branch=ci-coverall)  
 Minimalistic http server template in go that is:
 - Small (less than 300 lines of code)
 - Single file 


### PR DESCRIPTION
codecov has [bug](https://github.com/codecov/codecov-action/issues/1623#issuecomment-2466073573) not fixed for long time.. migrate to coverall

- **ci: Add shogo82148/goveralls github action**
- **docs: Update docs badge with coveralls**

Ref
- https://github.com/raeperd/test.go/pull/7
- https://github.com/codecov/codecov-action/issues/1623#issuecomment-2466073573
