### PR TITLE
code suggestion

### DIFF
--- a/main.go
+++ b/main.go
@@ -213,7 +213,7 @@ func recovery(next http.Handler, log *slog.Logger) http.Handler {
 				slog.String("ip", r.RemoteAddr))
 
 			if wr.status == 0 { // response is not written yet
-				http.Error(w, fmt.Sprintf("%v", err), http.StatusInternalServerError)
+				http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
 			}
 		}()
 		next.ServeHTTP(&wr, r)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"expvar"
 	"flag"
 	"fmt"
@@ -195,7 +196,8 @@ func recovery(next http.Handler, log *slog.Logger) http.Handler {
 				return
 			}
 
-			if err == http.ErrAbortHandler { // Handle the abort gracefully
+			if err, ok := err.(error); ok && errors.Is(err, http.ErrAbortHandler) {
+				// Handle the abort gracefully
 				return
 			}
 

--- a/main.go
+++ b/main.go
@@ -152,7 +152,7 @@ func handleGetDebug() http.Handler {
 func handleGetOpenAPI(version string) http.HandlerFunc {
 	body := bytes.Replace(openAPI, []byte("${{ VERSION }}"), []byte(version), 1)
 	return func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Type", "text/yaml")
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(body)

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func run(ctx context.Context, w io.Writer, args []string, version string) error 
 	var port uint
 	fs := flag.NewFlagSet(args[0], flag.ExitOnError)
 	fs.SetOutput(w)
-	fs.UintVar(&port, "port", 8080, "port for http api")
+	fs.UintVar(&port, "port", 8080, "port for HTTP API")
 	if err := fs.Parse(args[1:]); err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -212,9 +212,13 @@ func recovery(next http.Handler, log *slog.Logger) http.Handler {
 				slog.String("query", r.URL.RawQuery),
 				slog.String("ip", r.RemoteAddr))
 
-			if wr.status == 0 { // response is not written yet
-				http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
+			if wr.status > 0 {
+				// response was already sent, nothing we can do
+				return
 			}
+
+			// send error response
+			http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
 		}()
 		next.ServeHTTP(&wr, r)
 	})

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func run(ctx context.Context, w io.Writer, args []string, version string) error 
 		slog.InfoContext(ctx, "shutting down server")
 	}
 
-	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel = context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 	defer cancel()
 	return server.Shutdown(ctx)
 }

--- a/main.go
+++ b/main.go
@@ -51,8 +51,9 @@ func run(ctx context.Context, w io.Writer, args []string, version string) error 
 
 	slog.SetDefault(slog.New(slog.NewJSONHandler(w, nil)))
 	server := &http.Server{
-		Addr:    fmt.Sprintf(":%d", port),
-		Handler: route(slog.Default(), version),
+		Addr:              fmt.Sprintf(":%d", port),
+		Handler:           route(slog.Default(), version),
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	errChan := make(chan error, 1)

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func run(ctx context.Context, w io.Writer, args []string, version string) error 
 func route(log *slog.Logger, version string) http.Handler {
 	mux := http.NewServeMux()
 	mux.Handle("GET /health", handleGetHealth(version))
-	mux.Handle("GET /openapi.yaml", handleGetOpenapi(version))
+	mux.Handle("GET /openapi.yaml", handleGetOpenAPI(version))
 	mux.Handle("/debug/", handleGetDebug())
 
 	handler := accesslog(mux, log)
@@ -146,10 +146,10 @@ func handleGetDebug() http.Handler {
 	return mux
 }
 
-// handleGetOpenapi returns an [http.HandlerFunc] that serves the OpenAPI specification YAML file.
+// handleGetOpenAPI returns an [http.HandlerFunc] that serves the OpenAPI specification YAML file.
 // The file is embedded in the binary using the go:embed directive.
-func handleGetOpenapi(version string) http.HandlerFunc {
-	body := bytes.Replace(openapi, []byte("${{ VERSION }}"), []byte(version), 1)
+func handleGetOpenAPI(version string) http.HandlerFunc {
+	body := bytes.Replace(openAPI, []byte("${{ VERSION }}"), []byte(version), 1)
 	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.Header().Set("Access-Control-Allow-Origin", "*")
@@ -158,11 +158,11 @@ func handleGetOpenapi(version string) http.HandlerFunc {
 	}
 }
 
-// openapi holds the embedded OpenAPI YAML file.
+// openAPI holds the embedded OpenAPI YAML file.
 // Remove this and the api/openapi.yaml file if you prefer not to serve OpenAPI.
 //
 //go:embed api/openapi.yaml
-var openapi []byte
+var openAPI []byte
 
 // accesslog is a middleware that logs request and response details,
 // including latency, method, path, query parameters, IP address, response status, and bytes sent.

--- a/main.go
+++ b/main.go
@@ -119,7 +119,7 @@ func handleGetHealth(version string) http.HandlerFunc {
 	}
 
 	up := time.Now()
-	return func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
@@ -150,7 +150,7 @@ func handleGetDebug() http.Handler {
 // The file is embedded in the binary using the go:embed directive.
 func handleGetOpenapi(version string) http.HandlerFunc {
 	body := bytes.Replace(openapi, []byte("${{ VERSION }}"), []byte(version), 1)
-	return func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.WriteHeader(http.StatusOK)

--- a/main_test.go
+++ b/main_test.go
@@ -215,21 +215,21 @@ func TestRecoveryMiddleware(t *testing.T) {
 	}
 }
 
-func testEqual[T comparable](t testing.TB, want, got T) {
-	t.Helper()
+func testEqual[T comparable](tb testing.TB, want, got T) {
+	tb.Helper()
 	if want != got {
-		t.Fatalf("want: %v; got: %v", want, got)
+		tb.Fatalf("want: %v; got: %v", want, got)
 	}
 }
 
-func testNil(t testing.TB, err error) {
-	t.Helper()
-	testEqual(t, nil, err)
+func testNil(tb testing.TB, err error) {
+	tb.Helper()
+	testEqual(tb, nil, err)
 }
 
-func testContains(t testing.TB, needle string, haystack string) {
-	t.Helper()
+func testContains(tb testing.TB, needle string, haystack string) {
+	tb.Helper()
 	if !strings.Contains(haystack, needle) {
-		t.Fatalf("%q not in %q", needle, haystack)
+		tb.Fatalf("%q not in %q", needle, haystack)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -34,10 +34,9 @@ func TestMain(m *testing.M) {
 	}()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	go func() { // Start the server in a goroutine
 		if err := run(ctx, os.Stdout, []string{"test", "--port", port}, "vtest"); err != nil {
+			cancel()
 			log.Fatal(err)
 		}
 	}()
@@ -52,7 +51,9 @@ func TestMain(m *testing.M) {
 		time.Sleep(250 * time.Millisecond)
 	}
 
-	os.Exit(m.Run())
+	exitCode := m.Run()
+	cancel()
+	os.Exit(exitCode)
 }
 
 // endpoint holds the server endpoint started by TestMain, not intended to be updated.

--- a/main_test.go
+++ b/main_test.go
@@ -207,7 +207,7 @@ func TestRecoveryMiddleware(t *testing.T) {
 			rec := httptest.NewRecorder()
 			handler.ServeHTTP(rec, req)
 
-			testEqual(t, rec.Code, tt.wantCode)
+			testEqual(t, tt.wantCode, rec.Code)
 			if tt.wantPanic {
 				testContains(t, "panic!", buffer.String())
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -80,9 +80,9 @@ func TestGetHealth(t *testing.T) {
 	defer res.Body.Close()
 }
 
-// TestGetOpenapi tests the /openapi.yaml endpoint.
+// TestGetOpenAPI tests the /openapi.yaml endpoint.
 // You can add more test as needed without starting the server again.
-func TestGetOpenapi(t *testing.T) {
+func TestGetOpenAPI(t *testing.T) {
 	t.Parallel()
 	res, err := http.Get(endpoint + "/openapi.yaml")
 	testNil(t, err)

--- a/main_test.go
+++ b/main_test.go
@@ -203,7 +203,7 @@ func TestRecoveryMiddleware(t *testing.T) {
 			var buffer strings.Builder
 			handler := recovery(http.HandlerFunc(tt.hf), slog.New(slog.NewTextHandler(&buffer, nil)))
 
-			req := httptest.NewRequest("GET", "/test", nil)
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
 			rec := httptest.NewRecorder()
 			handler.ServeHTTP(rec, req)
 

--- a/main_test.go
+++ b/main_test.go
@@ -138,7 +138,7 @@ func TestAccessLogMiddleware(t *testing.T) {
 			t.Parallel()
 
 			var buffer strings.Builder
-			handler := accesslog(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handler := accesslog(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(tt.Status)
 				w.Write(tt.body) //nolint:errcheck
 			}), slog.New(slog.NewJSONHandler(&buffer, nil)))
@@ -172,7 +172,7 @@ func TestRecoveryMiddleware(t *testing.T) {
 	}{
 		{
 			name: "no panic on normal http.Handler",
-			hf: func(w http.ResponseWriter, r *http.Request) {
+			hf: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte("success")) //nolint:errcheck
 			},
@@ -181,7 +181,7 @@ func TestRecoveryMiddleware(t *testing.T) {
 		},
 		{
 			name: "no panic on http.ErrAbortHandler",
-			hf: func(w http.ResponseWriter, r *http.Request) {
+			hf: func(_ http.ResponseWriter, _ *http.Request) {
 				panic(http.ErrAbortHandler)
 			},
 			wantCode:  http.StatusOK,
@@ -189,7 +189,7 @@ func TestRecoveryMiddleware(t *testing.T) {
 		},
 		{
 			name: "panic on http.Handler",
-			hf: func(w http.ResponseWriter, r *http.Request) {
+			hf: func(_ http.ResponseWriter, _ *http.Request) {
 				panic("something went wrong")
 			},
 			wantCode:  http.StatusInternalServerError,

--- a/main_test.go
+++ b/main_test.go
@@ -74,10 +74,13 @@ func TestGetHealth(t *testing.T) {
 	// actual http request to the server.
 	res, err := http.Get(endpoint + "/health")
 	testNil(t, err)
+	t.Cleanup(func() {
+		err = res.Body.Close()
+		testNil(t, err)
+	})
 	testEqual(t, http.StatusOK, res.StatusCode)
 	testEqual(t, "application/json", res.Header.Get("Content-Type"))
 	testNil(t, json.NewDecoder(res.Body).Decode(&response{}))
-	defer res.Body.Close()
 }
 
 // TestGetOpenAPI tests the /openapi.yaml endpoint.
@@ -92,7 +95,10 @@ func TestGetOpenAPI(t *testing.T) {
 	sb := strings.Builder{}
 	_, err = io.Copy(&sb, res.Body)
 	testNil(t, err)
-	res.Body.Close()
+	t.Cleanup(func() {
+		err = res.Body.Close()
+		testNil(t, err)
+	})
 
 	testContains(t, "openapi: 3.1.0", sb.String())
 	testContains(t, "version: ", sb.String())

--- a/main_test.go
+++ b/main_test.go
@@ -91,7 +91,7 @@ func TestGetOpenAPI(t *testing.T) {
 	res, err := http.Get(endpoint + "/openapi.yaml")
 	testNil(t, err)
 	testEqual(t, http.StatusOK, res.StatusCode)
-	testEqual(t, "text/plain", res.Header.Get("Content-Type"))
+	testEqual(t, "text/yaml", res.Header.Get("Content-Type"))
 
 	sb := strings.Builder{}
 	_, err = io.Copy(&sb, res.Body)


### PR DESCRIPTION
- **chore: fix acronyms**
- **chore: use tb variable for testing.TB**
- **fix: potential Slowloris Attack**
- **refactor: restore the context, do not create one**
- **fix: use the expect Content-Type for OpenAPI**
- **chore: remove useless variables**
- **chore: rename method and variable to comply the acronym**
- **chore: use http constant**
- **test: fix inverted got-want**
- **test: make sure to close res.Body**
- **test: make sure to context is cancelled**
- **refactor: simplify panic recovery**
- **refactor: use type assertion and errors.Is to validate the server aborted**
- **refactor: do not use sprintf when sprint can be used**
- **refactor: invert if statement to make it clearer**
