### PR TITLE
ci: Fix doker tag error when version string contains `/` 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,14 +23,3 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
-
-  # Maintain dependencies for Docker
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      time: "00:00"
-      timezone: "Etc/UTC"
-    commit-message:
-      prefix: "ci"
-      include: "scope"

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,13 @@ clean:
 	rm -rf coverage.txt $(TARGET_EXEC) 
 
 IMAGE := ghcr.io/raeperd/kickstart
+DOCKER_VERSION := $(if $(VERSION),$(subst /,-,$(VERSION)),latest)
+
 docker:
-	docker build . --build-arg VERSION=$(VERSION) -t $(IMAGE):$(VERSION)
+	docker build . --build-arg VERSION=$(VERSION) -t $(IMAGE):$(DOCKER_VERSION)
 
 docker-run: docker 
-	docker run --rm -p $(PORT):8080 $(IMAGE):$(VERSION)
+	docker run --rm -p $(PORT):8080 $(IMAGE):$(DOCKER_VERSION)
 
 docker-clean:
-	docker image rm -f $(IMAGE):$(VERSION) || true
+	docker image rm -f $(IMAGE):$(DOCKER_VERSION) || true


### PR DESCRIPTION
- **ci: Fix docker tag error when version string has '/'**
- **ci: Remove docker dependabot**
    -  don't want automatic pr like https://github.com/raeperd/kickstart.go/pull/30
