### PR TITLE
ci: enable unqueryvet linter and update golangci-lint to v2.5

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,4 +30,4 @@ jobs:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.4
+          version: v2.5

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters:
     - unconvert
     - unparam
     - usestdlibvars
+    - unqueryvet
 
   settings:
     gocritic:


### PR DESCRIPTION
## Summary
- Enable unqueryvet linter in golangci-lint configuration
- Update golangci-lint action version from v2.4 to v2.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)