### PR TITLE
Fix potential nil pointer dereference in debug.ReadBuildInfo()

### DIFF
--- a/main.go
+++ b/main.go
@@ -151,18 +151,19 @@ func handleGetHealth(version string) http.HandlerFunc {
 	}
 
 	baseRes := responseBody{Version: version}
-	buildInfo, _ := debug.ReadBuildInfo()
-	for _, kv := range buildInfo.Settings {
-		if kv.Value == "" {
-			continue
-		}
-		switch kv.Key {
-		case "vcs.revision":
-			baseRes.LastCommitHash = kv.Value
-		case "vcs.time":
-			baseRes.LastCommitTime, _ = time.Parse(time.RFC3339, kv.Value)
-		case "vcs.modified":
-			baseRes.DirtyBuild = kv.Value == "true"
+	if buildInfo, ok := debug.ReadBuildInfo(); ok {
+		for _, kv := range buildInfo.Settings {
+			if kv.Value == "" {
+				continue
+			}
+			switch kv.Key {
+			case "vcs.revision":
+				baseRes.LastCommitHash = kv.Value
+			case "vcs.time":
+				baseRes.LastCommitTime, _ = time.Parse(time.RFC3339, kv.Value)
+			case "vcs.modified":
+				baseRes.DirtyBuild = kv.Value == "true"
+			}
 		}
 	}
 


### PR DESCRIPTION
Wrap the buildInfo.Settings iteration in an ok check from
debug.ReadBuildInfo() to prevent a nil pointer dereference when
build info is unavailable.

https://claude.ai/code/session_01TYaxekWR7DYkT6ApkDKFVi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of the health check endpoint to gracefully handle cases where build information is unavailable, ensuring the service remains stable in all deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->