### PR TITLE
refactor: use errors.Is for http.ErrServerClosed comparison

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func run(ctx context.Context, w io.Writer, getenv func(string) string, version s
 	errChan := make(chan error, 1)
 	go func() {
 		slog.InfoContext(ctx, "server started", slog.Uint64("port", uint64(port)), slog.String("version", version))
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errChan <- err
 		}
 	}()


### PR DESCRIPTION
## Summary
- Replace direct error comparison `err != http.ErrServerClosed` with `!errors.Is(err, http.ErrServerClosed)` for robustness against wrapped errors

## Test plan
- [x] `make test` passes
- [x] `make lint` passes