### PR TITLE
fix: pass PORT as env var in Makefile run target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ lint: download
 	go run golang.org/x/tools/cmd/deadcode@latest -test ./...
 
 run: build
-	./$(TARGET_EXEC) --port=$(PORT)
+	PORT=$(PORT) ./$(TARGET_EXEC)
 
 watch:
 	air 


### PR DESCRIPTION
## Summary
- The server was refactored in #58 to use the `PORT` environment variable instead of a `--port` CLI flag
- The Makefile `run` target was not updated, so `make run` passes `--port=8080` which the binary no longer accepts
- Changed `./$(TARGET_EXEC) --port=$(PORT)` to `PORT=$(PORT) ./$(TARGET_EXEC)`

## Test plan
- Run `make run` and verify the server starts on port 8080 without errors