### PR TITLE
fix: prevent signal notification goroutine leak

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,9 +49,7 @@ func run(ctx context.Context, w io.Writer, getenv func(string) string, version s
 	}
 
 	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
-
-	// NOTE: Removed `defer cancel()` since we want to control when to cancel the context
-	// We'll call it explicitly after server shutdown
+	defer cancel()
 
 	// Initialize your resources here, for example:
 	// - Database connections


### PR DESCRIPTION
## Summary
- Add `defer cancel()` after `signal.NotifyContext` in `run()` to ensure the signal notification goroutine is cleaned up on all exit paths
- Previously, when `ListenAndServe` failed via `errChan`, `cancel()` was never called, leaking the goroutine
- The explicit `cancel()` in the `ctx.Done()` branch is retained since calling cancel twice is safe per context documentation

## Test plan
- Existing tests pass with `make test` (87.9% coverage)
- Linter passes with `make lint` (0 issues)