### PR TITLE
fix: capture implicit HTTP 200 status in responseRecorder

### DIFF
--- a/main.go
+++ b/main.go
@@ -288,6 +288,8 @@ func (re *responseRecorder) Header() http.Header {
 
 // Write implements the [http.ResponseWriter] interface.
 func (re *responseRecorder) Write(b []byte) (int, error) {
+	// Mirror net/http's implicit 200 when Write is called without WriteHeader,
+	// so the access log records the correct status instead of 0.
 	if re.status == 0 {
 		re.status = http.StatusOK
 	}

--- a/main.go
+++ b/main.go
@@ -288,6 +288,9 @@ func (re *responseRecorder) Header() http.Header {
 
 // Write implements the [http.ResponseWriter] interface.
 func (re *responseRecorder) Write(b []byte) (int, error) {
+	if re.status == 0 {
+		re.status = http.StatusOK
+	}
 	re.numBytes += len(b)
 	return re.ResponseWriter.Write(b)
 }

--- a/main.go
+++ b/main.go
@@ -288,9 +288,7 @@ func (re *responseRecorder) Header() http.Header {
 
 // Write implements the [http.ResponseWriter] interface.
 func (re *responseRecorder) Write(b []byte) (int, error) {
-	// Mirror net/http's implicit 200 when Write is called without WriteHeader,
-	// so the access log records the correct status instead of 0.
-	if re.status == 0 {
+	if re.status == 0 { // mirror net/http's implicit 200 on first Write
 		re.status = http.StatusOK
 	}
 	re.numBytes += len(b)


### PR DESCRIPTION
## Summary
- Fix `responseRecorder.Write()` to set `status = http.StatusOK` when `WriteHeader()` has not been called, matching Go's implicit 200 behavior
- Resolves access log showing `"status":0` for endpoints like `/debug/vars` that call `Write()` without an explicit `WriteHeader()`

## Test plan
- Run `make test` — all existing tests pass
- Start the server and hit `GET /debug/vars`, verify the access log now shows `"status":200` instead of `"status":0`