### PR TITLE
fix: use camelCase JSON tags for health response and align test

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,11 +143,11 @@ func route(log *slog.Logger, version string) http.Handler {
 // The service version can be set at build time using the VERSION variable (e.g., 'make build VERSION=v1.0.0').
 func handleHealth(version string) http.HandlerFunc {
 	type responseBody struct {
-		Version        string    `json:"Version"`
-		Uptime         string    `json:"Uptime"`
-		LastCommitHash string    `json:"LastCommitHash"`
-		LastCommitTime time.Time `json:"LastCommitTime"`
-		DirtyBuild     bool      `json:"DirtyBuild"`
+		Version        string    `json:"version"`
+		Uptime         string    `json:"uptime"`
+		LastCommitHash string    `json:"lastCommitHash"`
+		LastCommitTime time.Time `json:"lastCommitTime"`
+		DirtyBuild     bool      `json:"dirtyBuild"`
 	}
 
 	baseRes := responseBody{Version: version}

--- a/main_test.go
+++ b/main_test.go
@@ -70,10 +70,11 @@ func TestGetHealth(t *testing.T) {
 	// response is repeated, but this describes intention of test better.
 	// For example, you can add fields only needed for testing.
 	type response struct {
-		Version  string    `json:"version"`
-		Revision string    `json:"vcs.revision"`
-		Time     time.Time `json:"vcs.time"`
-		// Modified bool      `json:"vcs.modified"`
+		Version        string    `json:"Version"`
+		Uptime         string    `json:"Uptime"`
+		LastCommitHash string    `json:"LastCommitHash"`
+		LastCommitTime time.Time `json:"LastCommitTime"`
+		DirtyBuild     bool      `json:"DirtyBuild"`
 	}
 
 	// actual http request to the server.
@@ -85,7 +86,13 @@ func TestGetHealth(t *testing.T) {
 	})
 	testEqual(t, http.StatusOK, res.StatusCode)
 	testEqual(t, "application/json", res.Header.Get("Content-Type"))
-	testNil(t, json.NewDecoder(res.Body).Decode(&response{}))
+
+	var body response
+	testNil(t, json.NewDecoder(res.Body).Decode(&body))
+	testEqual(t, "vtest", body.Version)
+	if body.Uptime == "" {
+		t.Fatal("expected non-empty Uptime")
+	}
 }
 
 // TestGetOpenAPI tests the /openapi.yaml endpoint.

--- a/main_test.go
+++ b/main_test.go
@@ -70,11 +70,11 @@ func TestGetHealth(t *testing.T) {
 	// response is repeated, but this describes intention of test better.
 	// For example, you can add fields only needed for testing.
 	type response struct {
-		Version        string    `json:"Version"`
-		Uptime         string    `json:"Uptime"`
-		LastCommitHash string    `json:"LastCommitHash"`
-		LastCommitTime time.Time `json:"LastCommitTime"`
-		DirtyBuild     bool      `json:"DirtyBuild"`
+		Version        string    `json:"version"`
+		Uptime         string    `json:"uptime"`
+		LastCommitHash string    `json:"lastCommitHash"`
+		LastCommitTime time.Time `json:"lastCommitTime"`
+		DirtyBuild     bool      `json:"dirtyBuild"`
 	}
 
 	// actual http request to the server.


### PR DESCRIPTION
## Summary
- Change health endpoint JSON tags from PascalCase (`Version`, `Uptime`) to idiomatic camelCase (`version`, `uptime`)
- Fix test struct tags that never matched the handler output — `json.Decode` silently produced zero values, so the test validated nothing
- Add assertions that `version` and `uptime` are actually populated

## Test plan
- `go test -race ./...` passes
- `curl /health` returns camelCase keys