### PR TITLE
fix: remove premature WriteHeader in handleHealth

### DIFF
--- a/main.go
+++ b/main.go
@@ -169,11 +169,10 @@ func handleHealth(version string) http.HandlerFunc {
 
 	up := time.Now()
 	return func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-
 		res := baseRes // Create a copy for each request to avoid data race
 		res.Uptime = time.Since(up).String()
+
+		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(res); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}


### PR DESCRIPTION
## Summary
- Remove explicit `w.WriteHeader(http.StatusOK)` before `json.Encode` in `handleHealth`
- Previously, the 200 status was committed before encoding, so `http.Error` could never send 500 on encode failure
- Now the implicit 200 from `w.Write` handles the success path, and `http.Error` works correctly on the error path

## Test plan
- `go test -race ./...` passes
- Verified manually: `/health` still returns 200 with correct JSON body