### PR TITLE
ci: add push trigger for main to update Coveralls badge

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,13 @@
 on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - 'Dockerfile'
+      - '.github/workflows/build.yaml'
   pull_request:
     paths:
       - '**/*.go'


### PR DESCRIPTION
## Summary
- Build workflow only had `pull_request` trigger, so Coveralls coverage on main was never updated after PRs merged
- Add `push` trigger for `main` branch with the same path filters

## Test plan
- [ ] Verify CI runs on this PR
- [ ] After merge, confirm Coveralls badge updates on next main push