### PR TITLE
refactor: replace inline go mod check with make tidy target

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,11 +16,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - name: check go mod
-        run: |
-          go mod download
-          go mod tidy
-          git diff --exit-code go.mod go.sum
+      - run: make tidy
+      - run: git diff --exit-code go.mod go.sum
       - run: make build VERSION=${{ github.ref_name }}
       - run: make test
       - uses: shogo82148/actions-goveralls@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /src
 COPY ./go.mod ./go.sum ./
 COPY ./Makefile .
 
-RUN make download
+RUN go mod download
 
 COPY . .
 

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,17 @@ VERSION := local
 
 default: clean build lint test 
 
-download:
+tidy:
 	go mod download
+	go mod tidy
 
-build: download
+build: tidy
 	go build -o $(TARGET_EXEC) -ldflags '-w -X main.Version=$(VERSION)' . 
 
 test:
 	go test -shuffle=on -race -coverprofile=coverage.txt ./...
 
-lint: download
+lint: tidy
 	golangci-lint run
 	go run golang.org/x/tools/cmd/deadcode@latest -test ./...
 


### PR DESCRIPTION
## Summary
- Rename `download` Makefile target to `tidy`, adding `go mod tidy`
- CI now uses `make tidy` + `git diff --exit-code` instead of inline commands
- Local dev and CI run the same commands

## Test plan
- [ ] Verify `make tidy` works locally
- [ ] Verify CI passes on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process consistency by refactoring how module dependencies are managed during the build and lint steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->