### PR TITLE
ci: remove redundant docker build from build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,8 +35,6 @@ jobs:
       - uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: coverage.txt
-      - run: make docker VERSION=${{ github.ref_name }}
-      - run: make clean
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Remove `make docker` and `make clean` steps from `build.yaml`
- `deploy.yaml` already handles Docker builds on push to main with the same path filters

## Test plan
- [ ] Verify CI passes without docker build step