### PR TITLE
refactor: simplify Makefile and make workflows template-friendly

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,11 +16,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - name: check go mod
-        run: |
-          go mod download
-          go mod tidy
-          git diff --exit-code go.mod go.sum
+      - run: make tidy
+      - run: git diff --exit-code go.mod go.sum
       - run: make build VERSION=${{ github.ref_name }}
       - run: make test
       - uses: shogo82148/actions-goveralls@v1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,9 +12,6 @@ on:
       - 'Dockerfile'
       - '.github/workflows/deploy.yaml'
 
-env:
-  REGISTRY_IMAGE: ghcr.io/raeperd/kickstart
-
 permissions:
   contents: read      # Required to checkout code
   packages: write     # Required to push to GHCR
@@ -27,7 +24,7 @@ jobs:
       - uses: docker/metadata-action@v6
         id: meta
         with:
-          images: ${{ env.REGISTRY_IMAGE }}
+          images: ghcr.io/${{ github.repository }}
       - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /src
 COPY ./go.mod ./go.sum ./
 COPY ./Makefile .
 
-RUN make download
+RUN go mod download
 
 COPY . .
 

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,17 @@ VERSION := local
 
 default: clean build lint test 
 
-download:
+tidy:
 	go mod download
+	go mod tidy
 
-build: download
+build: tidy
 	go build -o $(TARGET_EXEC) -ldflags '-w -X main.Version=$(VERSION)' . 
 
 test:
 	go test -shuffle=on -race -coverprofile=coverage.txt ./...
 
-lint: download
+lint: tidy
 	golangci-lint run
 	go run golang.org/x/tools/cmd/deadcode@latest -test ./...
 


### PR DESCRIPTION
## Summary
- Replace `download` target with `tidy` target in Makefile (`go mod download` + `go mod tidy`)
- Use `make tidy` in CI build workflow instead of inline go mod commands
- Use `go mod download` directly in Dockerfile instead of `make download`
- Replace hard-coded `ghcr.io/raeperd/kickstart` with `ghcr.io/${{ github.repository }}` in deploy workflow so it works automatically for template repos

## Test plan
- [ ] Verify `make build` and `make lint` still work locally
- [ ] Confirm CI build workflow passes
- [ ] Confirm deploy workflow resolves the correct image name