### PR TITLE
test: remove redundant test cases covered by integration tests

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -99,14 +99,6 @@ func TestGetHealth(t *testing.T) {
 func TestRunPort(t *testing.T) {
 	t.Parallel()
 
-	t.Run("default when PORT is unset", func(t *testing.T) {
-		t.Parallel()
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		err := run(ctx, io.Discard, func(string) string { return "" }, "vtest")
-		testNil(t, err)
-	})
-
 	invalidTests := []struct {
 		name string
 		port string
@@ -206,15 +198,6 @@ func TestRecoveryMiddleware(t *testing.T) {
 		wantCode  int
 		wantPanic bool
 	}{
-		{
-			name: "no panic on normal http.Handler",
-			hf: func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte("success")) //nolint:errcheck
-			},
-			wantCode:  http.StatusOK,
-			wantPanic: false,
-		},
 		{
 			name: "no panic on http.ErrAbortHandler",
 			hf: func(_ http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## Summary
- Remove `TestRunPort` "default when PORT is unset" subtest — the default port path is already exercised by `TestMain` server startup, and invalid port parsing is thoroughly covered by the remaining subtests.
- Remove `TestRecoveryMiddleware` "no panic on normal http.Handler" case — `TestGetHealth` already exercises the full middleware chain (including recovery) with a normal request.

## Test plan
- [x] `make test` passes with all remaining tests
- [x] Coverage remains at 81% — no meaningful coverage loss since these paths are covered by integration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed test cases for PORT configuration and recovery middleware behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->