### PR TITLE
refactor: remove redundant Header method from responseRecorder

### DIFF
--- a/main.go
+++ b/main.go
@@ -253,11 +253,6 @@ type responseRecorder struct {
 	numBytes int
 }
 
-// Header implements the [http.ResponseWriter] interface.
-func (re *responseRecorder) Header() http.Header {
-	return re.ResponseWriter.Header()
-}
-
 // Write implements the [http.ResponseWriter] interface.
 func (re *responseRecorder) Write(b []byte) (int, error) {
 	if re.status == 0 { // mirror net/http's implicit 200 on first Write


### PR DESCRIPTION
## Summary
- Remove the explicit `Header()` method from `responseRecorder` since the embedded `http.ResponseWriter` already promotes its `Header()` method automatically via Go's struct embedding.
- No behavior change; all existing tests pass.

## Test plan
- [x] `make test` passes with race detection and coverage