### PR TITLE
refactor: remove redundant tidy steps from Makefile and CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,9 +25,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - run: make tidy
-      - run: git diff --exit-code go.mod go.sum
       - run: make build VERSION=${{ github.ref_name }}
+      - run: git diff --exit-code go.mod go.sum
       - run: make test
       - uses: shogo82148/actions-goveralls@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ VERSION := local
 default: clean build lint test 
 
 tidy:
-	go mod download
 	go mod tidy
 
 build: tidy


### PR DESCRIPTION
## Summary

- **Makefile**: Remove `go mod download` from the `tidy` target since `go mod tidy` already downloads missing modules, making the explicit download redundant.
- **CI (build.yaml)**: Remove the standalone `make tidy` step since `make build` depends on `tidy` and runs it automatically. Move the `git diff --exit-code go.mod go.sum` check after `make build` to still catch untidy module files.

## Test plan

- [x] `make build` succeeds locally (tidy runs as a dependency)
- [x] `make test` passes with full coverage
- [ ] CI build workflow passes on this PR (tidy runs via build, diff check catches untidy modules)