### PR TITLE
refactor: remove docker-compose in favor of make docker-run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,12 +12,6 @@ kickstart.go is a minimalistic HTTP server template in Go that serves as a produ
 ```bash
 # Build and run server on port 8080
 make run
-
-# Hot reload development (requires air)
-make watch
-
-# Docker development environment
-docker-compose up
 ```
 
 ### Testing
@@ -105,9 +99,7 @@ When extending the server:
 
 ## Docker Development
 
-The docker-compose setup includes:
-- **app** service: Air hot reload container watching file changes
-- Health checks configured for production readiness
+Use `make docker-run` to build and run the Docker image locally.
 
 ## CI/CD Notes
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,0 @@
-services:
-  app:
-    build: .
-    ports:
-      - 8080:8080
-    environment:
-      PORT: "8080"


### PR DESCRIPTION
## Summary
- Remove `docker-compose.yaml` since `make docker-run` already provides the same functionality (build and run the Docker image)
- Update `CLAUDE.md` to reflect the removal and point to `make docker-run` instead

docker-compose added no value over `make docker-run` for a single-service template. Users can add it back when they need multi-service orchestration.

## Test plan
- [x] `make build` passes
- [x] `make test` passes (80.7% coverage, unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified Docker development instructions in developer guide; removed hot-reload and service configuration details.

* **Chores**
  * Removed Docker Compose service definition from local development setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->