### PR TITLE
refactor: trim comments and README for conciseness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,29 @@
 # kickstart.go
-[![.github/workflows/build.yaml](https://github.com/raeperd/kickstart.go/actions/workflows/build.yaml/badge.svg)](https://github.com/raeperd/kickstart.go/actions/workflows/build.yaml)  [![Go Report Card](https://goreportcard.com/badge/github.com/raeperd/kickstart.go)](https://goreportcard.com/report/github.com/raeperd/kickstart.go) [![Coverage Status](https://coveralls.io/repos/github/raeperd/kickstart.go/badge.svg?branch=main)](https://coveralls.io/github/raeperd/kickstart.go?branch=main) [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)  
-Minimalistic HTTP server template in Go that is:
-- Small (less than 300 lines of code)
-- Single file
-- Only standard library dependencies
+[![.github/workflows/build.yaml](https://github.com/raeperd/kickstart.go/actions/workflows/build.yaml/badge.svg)](https://github.com/raeperd/kickstart.go/actions/workflows/build.yaml)  [![Go Report Card](https://goreportcard.com/badge/github.com/raeperd/kickstart.go)](https://goreportcard.com/report/github.com/raeperd/kickstart.go) [![Coverage Status](https://coveralls.io/repos/github/raeperd/kickstart.go/badge.svg?branch=main)](https://coveralls.io/github/raeperd/kickstart.go?branch=main) [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)
 
-**Not** a framework, but a starting point for building HTTP services in Go.
-This project was first introduced in GopherCon Korea 2024, See [session in this link](https://www.youtube.com/live/DEZsPOSzNM0?si=ioPPAAb5JnOnpAoc&t=5113)(in Korean) and see [presentation in this link](https://raeperd.dev/go2024)(in English)
+Minimalistic HTTP server template in Go — single file, only standard library.
+**Not** a framework, but a starting point for building HTTP services.
 
-Inspired by [Mat Ryer](https://grafana.com/blog/2024/02/09/how-i-write-http-services-in-go-after-13-years) & [earthboundkid](https://blog.carlana.net/post/2023/golang-git-hash-how-to/) and even [kickstart.nvim](https://github.com/nvim-lua/kickstart.nvim)
+## Try it
+
+```console
+$ git clone https://github.com/raeperd/kickstart.go.git && cd kickstart.go
+$ make run
+$ curl localhost:8080/health
+{"version":"local","uptime":"1.23s","lastCommitHash":"abc1234","lastCommitTime":"2024-01-01T00:00:00Z","dirtyBuild":false}
+```
 
 ## Features
-- Graceful shutdown: Handles `SIGINT` and `SIGTERM` signals to shut down gracefully.
-- Health endpoint: Returns the server's health status including version and revision.
-- Debug information: Provides various debug metrics including `pprof` and `expvars`.
-- Access logging: Logs HTTP request details using `slog`.
-- Panic recovery: Catch and log panics in HTTP handlers gracefully.
-- Fully documented: Includes comments and documentation for all exported functions and types.
+- Graceful shutdown with `SIGINT`/`SIGTERM` signal handling
+- Health endpoint with version, git revision, and uptime
+- Debug endpoints (`pprof`, `expvar`) out of the box
+- Structured access logging and panic recovery middleware
+- Designed for testability — integration tests against a real server, no mocks
 
-## Getting started
-- Use this template to create a new repository
-- Or fork the repository and make changes to suit your needs.
-
-### Requirements
-Go 1.24 or later
-
-### Suggested Dependencies
-- [golangci-lint](https://golangci-lint.run/)
-- [air](https://github.com/air-verse/air)
-
-### Build and run the server
-
-```console
-$ make run
-```
-
-- this will build the server and run it on port 8080
-- Checkout Makefile for more
-
-## Endpoints
-- GET /health: Returns the health of the service, including version, revision, and modification status.
-- GET /debug/pprof: Returns the pprof debug information.
-- GET /debug/vars: Returns the expvars debug information.
-
-## How to
-
-### How to start a new project
-- Use this template to create a new repository
-- Or fork the repository and make changes to suit your needs.
-- Find and replace all strings `raeperd/kickstart.go` with your repository/image name
-
-### How to remove all comments from the code
-
-```console
-$ sed -i '' '/^\/\/go:embed/! {/^\s*\/\/.*$/d; /^\s*\/\*\*/,/\*\//d;}' *.go
-```
+## Start your own project
+- Use this template to create a new repository, or fork it
+- Find and replace all `raeperd/kickstart.go` with your repository name
 
 ## Reference
-- [GopherCon Korean 2024 Session](https://www.youtube.com/live/DEZsPOSzNM0?si=ioPPAAb5JnOnpAoc&t=5113) (in Korean)
-- [How I write HTTP services in Go after 13 years | Grafana Labs](https://grafana.com/blog/2024/02/09/how-i-write-http-services-in-go-after-13-years/)
+- [GopherCon Korea 2024 Session](https://www.youtube.com/live/DEZsPOSzNM0?si=ioPPAAb5JnOnpAoc&t=5113) (in Korean) / [Slides](https://raeperd.dev/go2024) (in English)
+- Inspired by [Mat Ryer](https://grafana.com/blog/2024/02/09/how-i-write-http-services-in-go-after-13-years), [earthboundkid](https://blog.carlana.net/post/2023/golang-git-hash-how-to/), and [kickstart.nvim](https://github.com/nvim-lua/kickstart.nvim)

--- a/main.go
+++ b/main.go
@@ -80,8 +80,7 @@ func run(ctx context.Context, w io.Writer, getenv func(string) string, version s
 	}
 }
 
-// route is the single source of truth for all endpoints and middleware.
-// All dependencies are passed as parameters for testability.
+// route is the single source of truth for all endpoints, middleware, and their dependencies.
 func route(log *slog.Logger, version string) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", handleHealth(version))

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func main() {
 var Version string
 
 // run starts the [http.Server] and blocks until shutdown via OS signal.
+// Dependencies are injected as parameters for testability.
 // Inspired by https://grafana.com/blog/2024/02/09/how-i-write-http-services-in-go-after-13-years
 func run(ctx context.Context, w io.Writer, getenv func(string) string, version string) error {
 	var port uint16 = 8080

--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ func run(ctx context.Context, w io.Writer, getenv func(string) string, version s
 }
 
 // route is the single source of truth for all endpoints and middleware.
+// All dependencies are passed as parameters for testability.
 func route(log *slog.Logger, version string) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", handleHealth(version))

--- a/main.go
+++ b/main.go
@@ -26,16 +26,11 @@ func main() {
 	}
 }
 
-// Version is set at build time using ldflags.
-// It is optional and can be omitted if not required.
-// Refer to [handleHealth] for more information.
+// Version is set at build time via ldflags (e.g., -X main.Version=v1.0.0).
 var Version string
 
-// run initiates and starts the [http.Server], blocking until the context is canceled by OS signals.
-// It listens on a port specified by the PORT environment variable, defaulting to 8080.
-// This function is inspired by techniques discussed in the [blog post] By Mat Ryer:
-//
-// [blog post]: https://grafana.com/blog/2024/02/09/how-i-write-http-services-in-go-after-13-years
+// run starts the server and blocks until shutdown via OS signal.
+// Inspired by https://grafana.com/blog/2024/02/09/how-i-write-http-services-in-go-after-13-years
 func run(ctx context.Context, w io.Writer, getenv func(string) string, version string) error {
 	var port uint16 = 8080
 	if p := getenv("PORT"); p != "" {
@@ -85,9 +80,7 @@ func run(ctx context.Context, w io.Writer, getenv func(string) string, version s
 	}
 }
 
-// route sets up and returns an [http.Handler] for all the server routes.
-// It is the single source of truth for all the routes.
-// You can add custom [http.Handler] as needed.
+// route registers all endpoints and wraps them with middleware.
 func route(log *slog.Logger, version string) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", handleHealth(version))
@@ -98,9 +91,7 @@ func route(log *slog.Logger, version string) http.Handler {
 	return handler
 }
 
-// handleHealth returns an [http.HandlerFunc] that responds with the health status of the service.
-// It includes the service version, VCS revision, build time, and modified status.
-// The service version can be set at build time using the VERSION variable (e.g., 'make build VERSION=v1.0.0').
+// handleHealth responds with service health including version and VCS info.
 func handleHealth(version string) http.HandlerFunc {
 	type responseBody struct {
 		Version        string    `json:"version"`
@@ -139,7 +130,7 @@ func handleHealth(version string) http.HandlerFunc {
 	}
 }
 
-// handleDebug returns an [http.HandlerFunc] for debug routes, including pprof and expvar routes.
+// handleDebug registers pprof and expvar routes under /debug/.
 func handleDebug() http.HandlerFunc {
 	mux := http.NewServeMux()
 
@@ -155,8 +146,7 @@ func handleDebug() http.HandlerFunc {
 	return mux.ServeHTTP
 }
 
-// accesslog is a middleware that logs request and response details,
-// including latency, method, path, query parameters, IP address, response status, and bytes sent.
+// accesslog logs request and response details.
 func accesslog(next http.Handler, log *slog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
@@ -175,8 +165,7 @@ func accesslog(next http.Handler, log *slog.Logger) http.HandlerFunc {
 	}
 }
 
-// recovery is a middleware that recovers from panics during HTTP handler execution and logs the error details.
-// It must be the last middleware in the chain to ensure it captures all panics.
+// recovery recovers from panics. Must be outermost middleware to catch all panics.
 func recovery(next http.Handler, log *slog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		wr := responseRecorder{ResponseWriter: w}
@@ -214,15 +203,14 @@ func recovery(next http.Handler, log *slog.Logger) http.HandlerFunc {
 	}
 }
 
-// responseRecorder is a wrapper around [http.ResponseWriter] that records the status and bytes written during the response.
-// It implements the [http.ResponseWriter] interface by embedding the original ResponseWriter.
+// responseRecorder wraps [http.ResponseWriter] to record status and bytes written.
 type responseRecorder struct {
 	http.ResponseWriter
 	status   int
 	numBytes int
 }
 
-// Write implements the [http.ResponseWriter] interface.
+// Write records bytes and implicit 200 status.
 func (re *responseRecorder) Write(b []byte) (int, error) {
 	if re.status == 0 { // mirror net/http's implicit 200 on first Write
 		re.status = http.StatusOK
@@ -231,7 +219,7 @@ func (re *responseRecorder) Write(b []byte) (int, error) {
 	return re.ResponseWriter.Write(b)
 }
 
-// WriteHeader implements the [http.ResponseWriter] interface.
+// WriteHeader records the status code.
 func (re *responseRecorder) WriteHeader(statusCode int) {
 	re.status = statusCode
 	re.ResponseWriter.WriteHeader(statusCode)

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 // Version is set at build time via ldflags (e.g., -X main.Version=v1.0.0).
 var Version string
 
-// run starts the server and blocks until shutdown via OS signal.
+// run starts the [http.Server] and blocks until shutdown via OS signal.
 // Inspired by https://grafana.com/blog/2024/02/09/how-i-write-http-services-in-go-after-13-years
 func run(ctx context.Context, w io.Writer, getenv func(string) string, version string) error {
 	var port uint16 = 8080
@@ -80,7 +80,7 @@ func run(ctx context.Context, w io.Writer, getenv func(string) string, version s
 	}
 }
 
-// route registers all endpoints and wraps them with middleware.
+// route is the single source of truth for all endpoints and middleware.
 func route(log *slog.Logger, version string) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", handleHealth(version))

--- a/main_test.go
+++ b/main_test.go
@@ -59,6 +59,7 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
+// endpoint is set by TestMain; do not modify.
 var endpoint string
 
 // TestGetHealth tests the /health endpoint against the real server.

--- a/main_test.go
+++ b/main_test.go
@@ -17,8 +17,7 @@ import (
 	"time"
 )
 
-// TestMain starts the server and runs all the tests.
-// By doing this, you can run **actual** integration tests without starting the server.
+// TestMain starts a real server for integration tests.
 func TestMain(m *testing.M) {
 	port := func() string { // Get a free port to run the server
 		listener, err := net.Listen("tcp", ":0")
@@ -60,15 +59,11 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
-// endpoint holds the server endpoint started by TestMain, not intended to be updated.
 var endpoint string
 
-// TestGetHealth tests the /health endpoint.
-// Server is started by [TestMain] so that the test can make requests to it.
+// TestGetHealth tests the /health endpoint against the real server.
 func TestGetHealth(t *testing.T) {
 	t.Parallel()
-	// response is repeated, but this describes intention of test better.
-	// For example, you can add fields only needed for testing.
 	type response struct {
 		Version        string    `json:"version"`
 		Uptime         string    `json:"uptime"`
@@ -77,7 +72,6 @@ func TestGetHealth(t *testing.T) {
 		DirtyBuild     bool      `json:"dirtyBuild"`
 	}
 
-	// actual http request to the server.
 	res, err := http.Get(endpoint + "/health")
 	testNil(t, err)
 	t.Cleanup(func() {
@@ -95,7 +89,7 @@ func TestGetHealth(t *testing.T) {
 	}
 }
 
-// TestRunPort tests port configuration via the PORT environment variable.
+// TestRunPort tests invalid PORT values.
 func TestRunPort(t *testing.T) {
 	t.Parallel()
 
@@ -126,7 +120,7 @@ func TestRunPort(t *testing.T) {
 	}
 }
 
-// TestAccessLogMiddleware tests accesslog middleware
+// TestAccessLogMiddleware verifies logged fields match request/response.
 func TestAccessLogMiddleware(t *testing.T) {
 	t.Parallel()
 
@@ -188,7 +182,7 @@ func TestAccessLogMiddleware(t *testing.T) {
 	}
 }
 
-// TestRecoveryMiddleware tests recovery middleware
+// TestRecoveryMiddleware verifies panic handling and ErrAbortHandler.
 func TestRecoveryMiddleware(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Condense verbose comments in `main.go` and `main_test.go` — each comment now describes purpose or non-obvious behavior, not implementation details readable from the code
- Add testability intent to `run()` comment
- Trim README from 62 to 28 lines: add "Try it" section, keep features for project philosophy, remove content derivable from code or Makefile

## Test plan
- [x] `make test` passes