### PR TITLE
feat: log shutdown signal cause

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func run(ctx context.Context, w io.Writer, getenv func(string) string, version s
 	case err := <-errChan:
 		return err
 	case <-ctx.Done():
-		slog.InfoContext(ctx, "shutting down server")
+		slog.InfoContext(ctx, "shutting down server", slog.Any("cause", context.Cause(ctx)))
 
 		// Create a new context for shutdown with timeout
 		ctx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)


### PR DESCRIPTION
## Summary
- Log which OS signal (SIGINT/SIGTERM) caused the server shutdown by adding `context.Cause(ctx)` to the shutdown log line
- Uses Go 1.26's `signal.NotifyContext` cancel cause, which automatically sets the context cause to the received signal

## Test plan
- [x] `make test` passes (all existing tests green)
- [x] `make lint` passes (0 issues)
- [ ] Manual: run server, send SIGINT (`Ctrl-C`), verify log includes `"cause":"signal: interrupt"`
- [ ] Manual: run server, send SIGTERM, verify log includes `"cause":"signal: terminated"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced server shutdown logging to include additional contextual details during server termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->