### PR TITLE
fix: hide panic details from clients

### DIFF
--- a/main.go
+++ b/main.go
@@ -198,7 +198,7 @@ func recovery(next http.Handler, log *slog.Logger) http.HandlerFunc {
 			}
 
 			// send error response
-			http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
+			http.Error(w, "internal server error", http.StatusInternalServerError)
 		}()
 		next.ServeHTTP(&wr, r)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -191,6 +191,7 @@ func TestRecoveryMiddleware(t *testing.T) {
 		name      string
 		hf        func(w http.ResponseWriter, r *http.Request)
 		wantCode  int
+		wantBody  string
 		wantPanic bool
 	}{
 		{
@@ -207,6 +208,7 @@ func TestRecoveryMiddleware(t *testing.T) {
 				panic("something went wrong")
 			},
 			wantCode:  http.StatusInternalServerError,
+			wantBody:  "internal server error\n",
 			wantPanic: true,
 		},
 	}
@@ -222,8 +224,10 @@ func TestRecoveryMiddleware(t *testing.T) {
 			handler.ServeHTTP(rec, req)
 
 			testEqual(t, tt.wantCode, rec.Code)
+			testEqual(t, tt.wantBody, rec.Body.String())
 			if tt.wantPanic {
 				testContains(t, "panic!", buffer.String())
+				testContains(t, "something went wrong", buffer.String())
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Return a generic `internal server error` response for recovered panics
- Keep the original panic value and stack trace in logs
- Add test coverage to ensure panic details are not exposed to clients

## Test

- `go test -race ./...`
- `golangci-lint run`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved server error handling to return a generic error message instead of detailed panic information when an error occurs.

* **Tests**
  * Enhanced test coverage for the recovery middleware to verify proper error response messages and panic logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->