### PR TITLE
Add server timeouts

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,6 +52,9 @@ func run(ctx context.Context, w io.Writer, getenv func(string) string, version s
 		Addr:              fmt.Sprintf(":%d", port),
 		Handler:           route(slog.Default(), version),
 		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	errChan := make(chan error, 1)


### PR DESCRIPTION
## Summary

Add explicit `net/http.Server` timeouts:

- `ReadTimeout: 30s`
- `WriteTimeout: 60s`
- `IdleTimeout: 60s`

`ReadHeaderTimeout` was already set to `10s`.

These defaults avoid unbounded request reads, response writes, and idle keep-alive connections while keeping the template simple. `WriteTimeout` is set to 60s so default pprof profiles can still complete.

Part of #85.

## Test

- `go test -race ./...`
- `golangci-lint run`
