### PR TITLE
Rename root route constructor to newRootHttpHandler

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func run(ctx context.Context, w io.Writer, getenv func(string) string, version s
 	slog.SetDefault(slog.New(slog.NewJSONHandler(w, nil)))
 	server := &http.Server{
 		Addr:              fmt.Sprintf(":%d", port),
-		Handler:           route(slog.Default(), version),
+		Handler:           newRootHttpHandler(slog.Default(), version),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
@@ -81,8 +81,8 @@ func run(ctx context.Context, w io.Writer, getenv func(string) string, version s
 	}
 }
 
-// route is the single source of truth for all endpoints, middleware, and their dependencies.
-func route(log *slog.Logger, version string) http.Handler {
+// newRootHttpHandler is the single source of truth for all endpoints, middleware, and their dependencies.
+func newRootHttpHandler(log *slog.Logger, version string) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", handleHealth(version))
 	mux.HandleFunc("/debug/", handleDebug())

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func run(ctx context.Context, w io.Writer, getenv func(string) string, version s
 	slog.SetDefault(slog.New(slog.NewJSONHandler(w, nil)))
 	server := &http.Server{
 		Addr:              fmt.Sprintf(":%d", port),
-		Handler:           newRootHttpHandler(slog.Default(), version),
+		Handler:           newRootHTTPHandler(slog.Default(), version),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
@@ -81,8 +81,8 @@ func run(ctx context.Context, w io.Writer, getenv func(string) string, version s
 	}
 }
 
-// newRootHttpHandler is the single source of truth for all endpoints, middleware, and their dependencies.
-func newRootHttpHandler(log *slog.Logger, version string) http.Handler {
+// newRootHTTPHandler is the single source of truth for all endpoints, middleware, and their dependencies.
+func newRootHTTPHandler(log *slog.Logger, version string) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", handleHealth(version))
 	mux.HandleFunc("/debug/", handleDebug())


### PR DESCRIPTION
### Motivation
- Clarify the root HTTP handler constructor name by renaming the generic `route` helper to a more explicit `newRootHttpHandler` so its purpose is clearer in server setup.

### Description
- Renamed the function `route` to `newRootHttpHandler` and updated the server initialization to use `newRootHttpHandler(log, version)` and adjusted the doc comment accordingly.

### Testing
- Ran `go test ./...` which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a468533c6d0833386ae16e52f833461)