### PR TITLE
ci: use official Coveralls uploader

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,6 +32,7 @@ jobs:
         with:
           file: coverage.txt
           format: golang
+          fail-on-error: false
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,9 +28,10 @@ jobs:
       - run: make build VERSION=${{ github.ref_name }}
       - run: git diff --exit-code go.mod go.sum
       - run: make test
-      - uses: shogo82148/actions-goveralls@v1
+      - uses: coverallsapp/github-action@v2
         with:
-          path-to-profile: coverage.txt
+          file: coverage.txt
+          format: golang
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- replace the community Go Coveralls uploader with Coveralls’ official v2 action
- explicitly upload `coverage.txt` as Go coverage data
- keep transient Coveralls service errors from blocking otherwise healthy CI

## Why
The main workflow’s build, tests, lint, and dead-code checks passed, but Coveralls returned HTTP 500 (`Build processing error`) from `/api/v1/jobs`. Retrying the original job and testing Coveralls’ official reporter initially reproduced the same server error, confirming the failure was external to this repository. A later run uploaded coverage successfully.

Coverage generation remains required; only the external upload transport is non-blocking.

## Validation
- `make build VERSION=main`
- `git diff --exit-code go.mod go.sum`
- `make test`
- `make lint`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/build.yaml`
- PR checks: build and lint passed; Coveralls accepted the Go coverage report