### PR TITLE
fix: correct HTTP middleware logging and recovery

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -8,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/pprof"
 	"os"
@@ -90,9 +92,7 @@ func newRootHTTPHandler(log *slog.Logger, version string) http.Handler {
 	mux.HandleFunc("GET /health", handleHealth(version))
 	mux.HandleFunc("/debug/", handleDebug())
 
-	handler := accesslog(mux, log)
-	handler = recovery(handler, log)
-	return handler
+	return requestOutcomes(mux, log)
 }
 
 // handleHealth responds with service health including version and VCS info.
@@ -150,43 +150,38 @@ func handleDebug() http.HandlerFunc {
 	return mux.ServeHTTP
 }
 
-// accesslog logs request and response details.
-func accesslog(next http.Handler, log *slog.Logger) http.HandlerFunc {
+// requestOutcomes owns response accounting, panic recovery, and the final access log.
+func requestOutcomes(next http.Handler, log *slog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		wr := responseRecorder{ResponseWriter: w}
-
-		next.ServeHTTP(&wr, r)
-
-		log.InfoContext(r.Context(), "accessed",
-			slog.String("latency", time.Since(start).String()),
-			slog.String("method", r.Method),
-			slog.String("path", r.URL.Path),
-			slog.String("query", r.URL.RawQuery),
-			slog.String("ip", r.RemoteAddr),
-			slog.Int("status", wr.status),
-			slog.Int("bytes", wr.numBytes))
-	}
-}
-
-// recovery recovers from panics. Must be outermost middleware to catch all panics.
-func recovery(next http.Handler, log *slog.Logger) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		wr := responseRecorder{ResponseWriter: w}
+		aborted := false
+		defer func() {
+			if !aborted && !wr.hijacked && !wr.committed() {
+				wr.status = http.StatusOK // net/http sends 200 when the handler returns without a final header.
+			}
+			log.InfoContext(r.Context(), "accessed",
+				slog.String("latency", time.Since(start).String()),
+				slog.String("method", r.Method),
+				slog.String("path", r.URL.Path),
+				slog.String("query", r.URL.RawQuery),
+				slog.String("ip", r.RemoteAddr),
+				slog.Int("status", wr.status),
+				slog.Int("bytes", wr.numBytes),
+				slog.Bool("aborted", aborted),
+				slog.Bool("hijacked", wr.hijacked))
+		}()
 		defer func() {
 			err := recover()
 			if err == nil {
 				return
 			}
-
-			if err, ok := err.(error); ok && errors.Is(err, http.ErrAbortHandler) {
-				// Handle the abort gracefully
-				return
+			aborted = true
+			if err == http.ErrAbortHandler {
+				panic(http.ErrAbortHandler) // Let net/http close the connection or reset the HTTP/2 stream.
 			}
-
 			stack := make([]byte, 1024)
 			n := runtime.Stack(stack, true)
-
 			log.ErrorContext(r.Context(), "panic!",
 				slog.Any("error", err),
 				slog.String("stack", string(stack[:n])),
@@ -194,14 +189,11 @@ func recovery(next http.Handler, log *slog.Logger) http.HandlerFunc {
 				slog.String("path", r.URL.Path),
 				slog.String("query", r.URL.RawQuery),
 				slog.String("ip", r.RemoteAddr))
-
-			if wr.status > 0 {
-				// response was already sent, nothing we can do
-				return
+			if wr.committed() || wr.hijacked {
+				panic(http.ErrAbortHandler) // A partial response cannot be replaced or completed safely.
 			}
-
-			// send error response
-			http.Error(w, "internal server error", http.StatusInternalServerError)
+			http.Error(&wr, "internal server error", http.StatusInternalServerError)
+			aborted = false
 		}()
 		next.ServeHTTP(&wr, r)
 	}
@@ -210,21 +202,71 @@ func recovery(next http.Handler, log *slog.Logger) http.HandlerFunc {
 // responseRecorder wraps [http.ResponseWriter] to record status and bytes written.
 type responseRecorder struct {
 	http.ResponseWriter
-	status   int
+	status   int // Zero means unwritten; 1xx except 101 is informational.
 	numBytes int
+	hijacked bool
 }
 
-// Write records bytes and implicit 200 status.
+// Write records bytes accepted by the writer and the implicit final 200 status.
 func (re *responseRecorder) Write(b []byte) (int, error) {
-	if re.status == 0 { // mirror net/http's implicit 200 on first Write
-		re.status = http.StatusOK
+	if !re.hijacked && !re.committed() {
+		re.status = http.StatusOK // Leave implicit header handling, including content sniffing, to Write.
 	}
-	re.numBytes += len(b)
-	return re.ResponseWriter.Write(b)
+	n, err := re.ResponseWriter.Write(b)
+	re.numBytes += n
+	return n, err
 }
 
-// WriteHeader records the status code.
+// WriteHeader remembers the last informational header or the first final header.
 func (re *responseRecorder) WriteHeader(statusCode int) {
-	re.status = statusCode
+	if re.hijacked || re.committed() {
+		return
+	}
 	re.ResponseWriter.WriteHeader(statusCode)
+	re.status = statusCode
+}
+
+// Unwrap preserves ResponseController operations such as pprof's write deadline.
+func (re *responseRecorder) Unwrap() http.ResponseWriter {
+	return re.ResponseWriter
+}
+
+// Flush preserves the Flusher interface for streaming handlers.
+func (re *responseRecorder) Flush() {
+	_ = re.FlushError()
+}
+
+// FlushError intercepts flushes because a supported flush commits an implicit 200,
+// even when flushing buffered data fails. An unsupported flush commits nothing.
+func (re *responseRecorder) FlushError() error {
+	w := re.ResponseWriter
+	for {
+		switch f := w.(type) {
+		case interface{ FlushError() error }, http.Flusher:
+			if !re.hijacked && !re.committed() {
+				re.WriteHeader(http.StatusOK)
+			}
+			return http.NewResponseController(w).Flush()
+		case interface{ Unwrap() http.ResponseWriter }:
+			w = f.Unwrap()
+		default:
+			return http.ErrNotSupported
+		}
+	}
+}
+
+// Hijack transfers ownership of the connection; subsequent raw writes cannot be
+// counted as HTTP response bytes, and net/http will not supply an implicit 200.
+func (re *responseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	conn, rw, err := http.NewResponseController(re.ResponseWriter).Hijack()
+	if err == nil {
+		re.hijacked = true
+	}
+	return conn, rw, err
+}
+
+// committed reports whether a final status has been accepted. Other 1xx headers
+// are informational; 101 switches protocols and is final in net/http.
+func (re *responseRecorder) committed() bool {
+	return re.status >= 200 || re.status == http.StatusSwitchingProtocols
 }

--- a/main.go
+++ b/main.go
@@ -89,7 +89,8 @@ func newRootHTTPHandler(log *slog.Logger, version string) http.Handler {
 	mux.HandleFunc("GET /health", handleHealth(version))
 	mux.HandleFunc("/debug/", handleDebug())
 
-	return requestOutcomes(mux, log)
+	handler := recovery(mux, log)
+	return accesslog(handler, log)
 }
 
 // handleHealth responds with service health including version and VCS info.
@@ -147,14 +148,15 @@ func handleDebug() http.HandlerFunc {
 	return mux.ServeHTTP
 }
 
-// requestOutcomes owns response accounting, panic recovery, and the final access log.
-func requestOutcomes(next http.Handler, log *slog.Logger) http.HandlerFunc {
+// accesslog logs the final response, including recovered panics and aborted requests.
+// Place it outside recovery so it observes the response recovery writes.
+func accesslog(next http.Handler, log *slog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		wr := responseRecorder{ResponseWriter: w, protoMajor: r.ProtoMajor}
-		aborted := false
+		completed := false
 		defer func() {
-			if !aborted && !wr.committed() {
+			if completed && !wr.committed() {
 				wr.status = http.StatusOK // net/http sends 200 when the handler returns without a final header.
 			}
 			log.InfoContext(r.Context(), "accessed",
@@ -165,14 +167,23 @@ func requestOutcomes(next http.Handler, log *slog.Logger) http.HandlerFunc {
 				slog.String("ip", r.RemoteAddr),
 				slog.Int("status", wr.status),
 				slog.Int("bytes", wr.numBytes),
-				slog.Bool("aborted", aborted))
+				slog.Bool("aborted", !completed))
 		}()
+		next.ServeHTTP(&wr, r)
+		completed = true
+	}
+}
+
+// recovery sends a generic 500 before a final response is committed, and aborts
+// the connection or stream if a panic interrupts an already committed response.
+func recovery(next http.Handler, log *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		wr := responseRecorder{ResponseWriter: w, protoMajor: r.ProtoMajor}
 		defer func() {
 			err := recover()
 			if err == nil {
 				return
 			}
-			aborted = true
 			if err == http.ErrAbortHandler {
 				panic(http.ErrAbortHandler) // Let net/http close the connection or reset the HTTP/2 stream.
 			}
@@ -187,7 +198,6 @@ func requestOutcomes(next http.Handler, log *slog.Logger) http.HandlerFunc {
 				panic(http.ErrAbortHandler) // A partial response cannot be replaced or completed safely.
 			}
 			http.Error(&wr, "internal server error", http.StatusInternalServerError)
-			aborted = false
 		}()
 		next.ServeHTTP(&wr, r)
 	}

--- a/main.go
+++ b/main.go
@@ -154,7 +154,7 @@ func handleDebug() http.HandlerFunc {
 func requestOutcomes(next http.Handler, log *slog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
-		wr := responseRecorder{ResponseWriter: w}
+		wr := responseRecorder{ResponseWriter: w, protoMajor: r.ProtoMajor}
 		aborted := false
 		defer func() {
 			if !aborted && !wr.hijacked && !wr.committed() {
@@ -202,9 +202,10 @@ func requestOutcomes(next http.Handler, log *slog.Logger) http.HandlerFunc {
 // responseRecorder wraps [http.ResponseWriter] to record status and bytes written.
 type responseRecorder struct {
 	http.ResponseWriter
-	status   int // Zero means unwritten; 1xx except 101 is informational.
-	numBytes int
-	hijacked bool
+	status     int // Zero means unwritten; 1xx is informational except HTTP/1.x 101.
+	protoMajor int
+	numBytes   int
+	hijacked   bool
 }
 
 // Write records bytes accepted by the writer and the implicit final 200 status.
@@ -265,8 +266,8 @@ func (re *responseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return conn, rw, err
 }
 
-// committed reports whether a final status has been accepted. Other 1xx headers
-// are informational; 101 switches protocols and is final in net/http.
+// committed reports whether a final status has been accepted. net/http treats
+// 101 as final only for HTTP/1.x; every 1xx header is informational under HTTP/2.
 func (re *responseRecorder) committed() bool {
-	return re.status >= 200 || re.status == http.StatusSwitchingProtocols
+	return re.status >= 200 || (re.protoMajor == 1 && re.status == http.StatusSwitchingProtocols)
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -9,12 +8,10 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net"
 	"net/http"
 	"net/http/pprof"
 	"os"
 	"os/signal"
-	"runtime"
 	"runtime/debug"
 	"strconv"
 	"syscall"
@@ -157,7 +154,7 @@ func requestOutcomes(next http.Handler, log *slog.Logger) http.HandlerFunc {
 		wr := responseRecorder{ResponseWriter: w, protoMajor: r.ProtoMajor}
 		aborted := false
 		defer func() {
-			if !aborted && !wr.hijacked && !wr.committed() {
+			if !aborted && !wr.committed() {
 				wr.status = http.StatusOK // net/http sends 200 when the handler returns without a final header.
 			}
 			log.InfoContext(r.Context(), "accessed",
@@ -168,8 +165,7 @@ func requestOutcomes(next http.Handler, log *slog.Logger) http.HandlerFunc {
 				slog.String("ip", r.RemoteAddr),
 				slog.Int("status", wr.status),
 				slog.Int("bytes", wr.numBytes),
-				slog.Bool("aborted", aborted),
-				slog.Bool("hijacked", wr.hijacked))
+				slog.Bool("aborted", aborted))
 		}()
 		defer func() {
 			err := recover()
@@ -180,16 +176,14 @@ func requestOutcomes(next http.Handler, log *slog.Logger) http.HandlerFunc {
 			if err == http.ErrAbortHandler {
 				panic(http.ErrAbortHandler) // Let net/http close the connection or reset the HTTP/2 stream.
 			}
-			stack := make([]byte, 1024)
-			n := runtime.Stack(stack, true)
 			log.ErrorContext(r.Context(), "panic!",
 				slog.Any("error", err),
-				slog.String("stack", string(stack[:n])),
+				slog.String("stack", string(debug.Stack())),
 				slog.String("method", r.Method),
 				slog.String("path", r.URL.Path),
 				slog.String("query", r.URL.RawQuery),
 				slog.String("ip", r.RemoteAddr))
-			if wr.committed() || wr.hijacked {
+			if wr.committed() {
 				panic(http.ErrAbortHandler) // A partial response cannot be replaced or completed safely.
 			}
 			http.Error(&wr, "internal server error", http.StatusInternalServerError)
@@ -205,12 +199,11 @@ type responseRecorder struct {
 	status     int // Zero means unwritten; 1xx is informational except HTTP/1.x 101.
 	protoMajor int
 	numBytes   int
-	hijacked   bool
 }
 
 // Write records bytes accepted by the writer and the implicit final 200 status.
 func (re *responseRecorder) Write(b []byte) (int, error) {
-	if !re.hijacked && !re.committed() {
+	if !re.committed() {
 		re.status = http.StatusOK // Leave implicit header handling, including content sniffing, to Write.
 	}
 	n, err := re.ResponseWriter.Write(b)
@@ -220,50 +213,26 @@ func (re *responseRecorder) Write(b []byte) (int, error) {
 
 // WriteHeader remembers the last informational header or the first final header.
 func (re *responseRecorder) WriteHeader(statusCode int) {
-	if re.hijacked || re.committed() {
+	if re.committed() {
 		return
 	}
 	re.ResponseWriter.WriteHeader(statusCode)
 	re.status = statusCode
 }
 
-// Unwrap preserves ResponseController operations such as pprof's write deadline.
-func (re *responseRecorder) Unwrap() http.ResponseWriter {
-	return re.ResponseWriter
-}
-
-// Flush preserves the Flusher interface for streaming handlers.
-func (re *responseRecorder) Flush() {
-	_ = re.FlushError()
-}
-
-// FlushError intercepts flushes because a supported flush commits an implicit 200,
-// even when flushing buffered data fails. An unsupported flush commits nothing.
+// FlushError records net/http's implicit 200 even if flushing buffered data fails.
 func (re *responseRecorder) FlushError() error {
-	w := re.ResponseWriter
-	for {
-		switch f := w.(type) {
-		case interface{ FlushError() error }, http.Flusher:
-			if !re.hijacked && !re.committed() {
-				re.WriteHeader(http.StatusOK)
-			}
-			return http.NewResponseController(w).Flush()
-		case interface{ Unwrap() http.ResponseWriter }:
-			w = f.Unwrap()
-		default:
-			return http.ErrNotSupported
-		}
+	err := http.NewResponseController(re.ResponseWriter).Flush()
+	if !errors.Is(err, http.ErrNotSupported) && !re.committed() {
+		re.status = http.StatusOK
 	}
+	return err
 }
 
-// Hijack transfers ownership of the connection; subsequent raw writes cannot be
-// counted as HTTP response bytes, and net/http will not supply an implicit 200.
-func (re *responseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	conn, rw, err := http.NewResponseController(re.ResponseWriter).Hijack()
-	if err == nil {
-		re.hijacked = true
-	}
-	return conn, rw, err
+// SetWriteDeadline supports pprof's deadline extension without exposing Unwrap,
+// which would also allow connection takeover to bypass response accounting.
+func (re *responseRecorder) SetWriteDeadline(deadline time.Time) error {
+	return http.NewResponseController(re.ResponseWriter).SetWriteDeadline(deadline)
 }
 
 // committed reports whether a final status has been accepted. net/http treats

--- a/main_test.go
+++ b/main_test.go
@@ -373,6 +373,86 @@ func TestRequestOutcomes(t *testing.T) {
 	}
 }
 
+func TestRequestOutcomesHTTP2Informational(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name    string
+		handler http.HandlerFunc
+		status  int
+		body    string
+	}{
+		{
+			name: "explicit final status",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+				_, _ = io.WriteString(w, "created")
+			},
+			status: http.StatusCreated,
+			body:   "created",
+		},
+		{
+			name:    "implicit final status",
+			handler: func(http.ResponseWriter, *http.Request) {},
+			status:  http.StatusOK,
+		},
+		{
+			name:    "recovered panic",
+			handler: func(http.ResponseWriter, *http.Request) { panic("private panic details") },
+			status:  http.StatusInternalServerError,
+			body:    "internal server error\n",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var buffer bytes.Buffer
+			handler := requestOutcomes(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusSwitchingProtocols)
+				tt.handler.ServeHTTP(w, r)
+			}), slog.New(slog.NewJSONHandler(&buffer, nil)))
+			server := httptest.NewUnstartedServer(handler)
+			server.EnableHTTP2 = true
+			server.StartTLS()
+			t.Cleanup(server.Close)
+			server.Client().Timeout = 5 * time.Second
+			var informational []int
+			trace := &httptrace.ClientTrace{Got1xxResponse: func(code int, _ textproto.MIMEHeader) error {
+				informational = append(informational, code)
+				return nil
+			}}
+			req, err := http.NewRequestWithContext(httptrace.WithClientTrace(context.Background(), trace), http.MethodGet, server.URL, nil)
+			testNil(t, err)
+			res, err := server.Client().Do(req)
+			testNil(t, err)
+			body, err := io.ReadAll(res.Body)
+			testNil(t, res.Body.Close())
+			testNil(t, err)
+			testEqual(t, 2, res.ProtoMajor)
+			testEqual(t, tt.status, res.StatusCode)
+			testEqual(t, tt.body, string(body))
+			testEqual(t, true, slices.Equal([]int{http.StatusSwitchingProtocols}, informational))
+			server.Close()
+			decoder := json.NewDecoder(&buffer)
+			accesses := 0
+			for decoder.More() {
+				var record struct {
+					Message string `json:"msg"`
+					Status  int    `json:"status"`
+					Bytes   int    `json:"bytes"`
+					Aborted bool   `json:"aborted"`
+				}
+				testNil(t, decoder.Decode(&record))
+				if record.Message == "accessed" {
+					accesses++
+					testEqual(t, tt.status, record.Status)
+					testEqual(t, len(tt.body), record.Bytes)
+					testEqual(t, false, record.Aborted)
+				}
+			}
+			testEqual(t, 1, accesses)
+		})
+	}
+}
+
 func TestRequestOutcomesImplicitHeaders(t *testing.T) {
 	t.Parallel()
 	var buffer bytes.Buffer

--- a/main_test.go
+++ b/main_test.go
@@ -4,13 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log"
 	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httptrace"
+	"net/textproto"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -121,117 +125,433 @@ func TestRunPort(t *testing.T) {
 	}
 }
 
-// TestAccessLogMiddleware verifies logged fields match request/response.
-func TestAccessLogMiddleware(t *testing.T) {
+// TestRequestOutcomes checks the response on the wire and its final access record.
+func TestRequestOutcomes(t *testing.T) {
 	t.Parallel()
-
-	type record struct {
-		Method string `json:"method"`
-		Path   string `json:"path"`
-		Query  string `json:"query"`
-		Status int    `json:"status"`
-		body   []byte `json:"-"`
-		Bytes  int    `json:"bytes"`
-	}
-
-	tests := []record{
-		{
-			Method: "GET",
-			Path:   "/test",
-			Query:  "?key=value",
-			Status: http.StatusOK,
-			body:   []byte(`{"hello":"world"}`),
-		},
-		{
-			Method: "POST",
-			Path:   "/api",
-			Status: http.StatusCreated,
-			body:   []byte(`{"id":1}`),
-		},
-		{
-			Method: "DELETE",
-			Path:   "/users/1",
-			Status: http.StatusNoContent,
-		},
-	}
-
-	for _, tt := range tests {
-		name := strings.Join([]string{tt.Method, tt.Path, tt.Query, strconv.Itoa(tt.Status)}, " ")
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			var buffer strings.Builder
-			handler := accesslog(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(tt.Status)
-				w.Write(tt.body) //nolint:errcheck
-			}), slog.New(slog.NewJSONHandler(&buffer, nil)))
-
-			req := httptest.NewRequest(tt.Method, tt.Path+tt.Query, bytes.NewReader(tt.body))
-			rec := httptest.NewRecorder()
-			handler.ServeHTTP(rec, req)
-
-			var log record
-			err := json.NewDecoder(strings.NewReader(buffer.String())).Decode(&log)
-			testNil(t, err)
-
-			testEqual(t, tt.Method, log.Method)
-			testEqual(t, tt.Path, log.Path)
-			testEqual(t, strings.TrimPrefix(tt.Query, "?"), log.Query)
-			testEqual(t, len(tt.body), log.Bytes)
-			testEqual(t, tt.Status, log.Status)
-		})
-	}
-}
-
-// TestRecoveryMiddleware verifies panic handling and ErrAbortHandler.
-func TestRecoveryMiddleware(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
-		name      string
-		hf        func(w http.ResponseWriter, r *http.Request)
-		wantCode  int
-		wantBody  string
-		wantPanic bool
+		name          string
+		handler       http.HandlerFunc
+		status        int
+		body          string
+		panicLog      bool
+		informational []int
+		aborted       bool
+		noResponse    bool
 	}{
 		{
-			name: "no panic on http.ErrAbortHandler",
-			hf: func(_ http.ResponseWriter, _ *http.Request) {
-				panic(http.ErrAbortHandler)
+			name: "normal response",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+				_, _ = io.WriteString(w, "created")
 			},
-			wantCode:  http.StatusOK,
-			wantPanic: false,
+			status: http.StatusCreated,
+			body:   "created",
 		},
 		{
-			name: "panic on http.Handler",
-			hf: func(_ http.ResponseWriter, _ *http.Request) {
-				panic("something went wrong")
+			name:    "empty response",
+			handler: func(http.ResponseWriter, *http.Request) {},
+			status:  http.StatusOK,
+		},
+		{
+			name:    "implicit status",
+			handler: func(w http.ResponseWriter, _ *http.Request) { _, _ = io.WriteString(w, "ok") },
+			status:  http.StatusOK,
+			body:    "ok",
+		},
+		{
+			name: "duplicate final headers",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+				w.WriteHeader(http.StatusInternalServerError)
+				w.WriteHeader(http.StatusEarlyHints)
 			},
-			wantCode:  http.StatusInternalServerError,
-			wantBody:  "internal server error\n",
-			wantPanic: true,
+			status: http.StatusCreated,
+		},
+		{
+			name: "informational then final",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusEarlyHints)
+				w.WriteHeader(http.StatusProcessing)
+				w.WriteHeader(http.StatusCreated)
+			},
+			status:        http.StatusCreated,
+			informational: []int{http.StatusEarlyHints, http.StatusProcessing},
+		},
+		{
+			name:          "informational then return",
+			handler:       func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusEarlyHints) },
+			status:        http.StatusOK,
+			informational: []int{http.StatusEarlyHints},
+		},
+		{
+			name: "informational then panic",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusEarlyHints)
+				panic("private panic details")
+			},
+			status:        http.StatusInternalServerError,
+			body:          "internal server error\n",
+			panicLog:      true,
+			informational: []int{http.StatusEarlyHints},
+		},
+		{
+			name: "controller capabilities and direct flush",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				controller := http.NewResponseController(w)
+				if err := controller.SetReadDeadline(time.Now().Add(time.Minute)); err != nil {
+					panic(err)
+				}
+				if err := controller.SetWriteDeadline(time.Now().Add(time.Minute)); err != nil {
+					panic(err)
+				}
+				if err := controller.EnableFullDuplex(); err != nil {
+					panic(err)
+				}
+				w.(http.Flusher).Flush()
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			status: http.StatusOK,
+		},
+		{
+			name: "flush commits implicit status",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				if err := http.NewResponseController(w).Flush(); err != nil {
+					panic(err)
+				}
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = io.WriteString(w, "ok")
+			},
+			status: http.StatusOK,
+			body:   "ok",
+		},
+		{
+			name: "panic after informational header and flush",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusEarlyHints)
+				if err := http.NewResponseController(w).Flush(); err != nil {
+					panic(err)
+				}
+				panic("private panic details")
+			},
+			status:        http.StatusOK,
+			informational: []int{http.StatusEarlyHints},
+			panicLog:      true,
+			aborted:       true,
+		},
+		{
+			name: "abort after flushed write",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+				_, _ = io.WriteString(w, "partial")
+				if err := http.NewResponseController(w).Flush(); err != nil {
+					panic(err)
+				}
+				panic(http.ErrAbortHandler)
+			},
+			status:  http.StatusCreated,
+			body:    "partial",
+			aborted: true,
+		},
+		{
+			name:       "abort before writing",
+			handler:    func(http.ResponseWriter, *http.Request) { panic(http.ErrAbortHandler) },
+			aborted:    true,
+			noResponse: true,
+		},
+		{
+			name: "abort after informational header",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusEarlyHints)
+				panic(http.ErrAbortHandler)
+			},
+			status:        http.StatusEarlyHints,
+			informational: []int{http.StatusEarlyHints},
+			aborted:       true,
+			noResponse:    true,
+		},
+		{
+			name: "panic after buffered write",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+				_, _ = io.WriteString(w, "partial")
+				panic("private panic details")
+			},
+			status:     http.StatusCreated,
+			body:       "partial",
+			panicLog:   true,
+			aborted:    true,
+			noResponse: true,
+		},
+		{
+			name:     "panic before writing",
+			handler:  func(http.ResponseWriter, *http.Request) { panic("private panic details") },
+			status:   http.StatusInternalServerError,
+			body:     "internal server error\n",
+			panicLog: true,
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			var buffer strings.Builder
-			handler := recovery(http.HandlerFunc(tt.hf), slog.New(slog.NewTextHandler(&buffer, nil)))
-
-			req := httptest.NewRequest(http.MethodGet, "/test", nil)
-			rec := httptest.NewRecorder()
-			handler.ServeHTTP(rec, req)
-
-			testEqual(t, tt.wantCode, rec.Code)
-			testEqual(t, tt.wantBody, rec.Body.String())
-			if tt.wantPanic {
-				testContains(t, "panic!", buffer.String())
-				testContains(t, "something went wrong", buffer.String())
+			var buffer bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buffer, nil))
+			server := httptest.NewServer(requestOutcomes(tt.handler, logger))
+			t.Cleanup(server.Close)
+			server.Client().Timeout = 5 * time.Second
+			var informational []int
+			trace := &httptrace.ClientTrace{Got1xxResponse: func(code int, _ textproto.MIMEHeader) error {
+				informational = append(informational, code)
+				return nil
+			}}
+			req, err := http.NewRequestWithContext(httptrace.WithClientTrace(context.Background(), trace), http.MethodGet, server.URL+"/test?key=value", nil)
+			testNil(t, err)
+			res, err := server.Client().Do(req)
+			if tt.noResponse {
+				if err == nil {
+					_ = res.Body.Close()
+					t.Fatal("expected the connection to abort without a final response")
+				}
+				if !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+					t.Fatalf("expected connection EOF, got %v", err)
+				}
+			} else {
+				testNil(t, err)
+				body, readErr := io.ReadAll(res.Body)
+				testNil(t, res.Body.Close())
+				if tt.aborted {
+					testEqual(t, io.ErrUnexpectedEOF, readErr)
+				} else {
+					testNil(t, readErr)
+				}
+				testEqual(t, tt.status, res.StatusCode)
+				testEqual(t, tt.body, string(body))
 			}
+			if !slices.Equal(tt.informational, informational) {
+				t.Fatalf("informational statuses: want %v; got %v", tt.informational, informational)
+			}
+			server.Close() // Wait for handlers before reading their logs.
+
+			var accesses, panics int
+			decoder := json.NewDecoder(&buffer)
+			for decoder.More() {
+				var record struct {
+					Message string `json:"msg"`
+					Method  string `json:"method"`
+					Path    string `json:"path"`
+					Query   string `json:"query"`
+					IP      string `json:"ip"`
+					Latency string `json:"latency"`
+					Status  int    `json:"status"`
+					Bytes   int    `json:"bytes"`
+					Error   string `json:"error"`
+					Stack   string `json:"stack"`
+					Aborted bool   `json:"aborted"`
+				}
+				testNil(t, decoder.Decode(&record))
+				switch record.Message {
+				case "accessed":
+					accesses++
+					testEqual(t, http.MethodGet, record.Method)
+					testEqual(t, "/test", record.Path)
+					testEqual(t, "key=value", record.Query)
+					testEqual(t, tt.status, record.Status)
+					testEqual(t, tt.aborted, record.Aborted)
+					testEqual(t, len(tt.body), record.Bytes)
+					_, _, err := net.SplitHostPort(record.IP)
+					testNil(t, err)
+					_, err = time.ParseDuration(record.Latency)
+					testNil(t, err)
+				case "panic!":
+					panics++
+					testContains(t, "private panic details", record.Error)
+					testContains(t, "goroutine", record.Stack)
+				}
+			}
+			testEqual(t, 1, accesses)
+			testEqual(t, tt.panicLog, panics == 1)
 		})
 	}
 }
+
+func TestRequestOutcomesImplicitHeaders(t *testing.T) {
+	t.Parallel()
+	var buffer bytes.Buffer
+	handler := requestOutcomes(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "<html></html>")
+	}), slog.New(slog.NewJSONHandler(&buffer, nil)))
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+	res := recorder.Result()
+	defer res.Body.Close() //nolint:errcheck
+	testEqual(t, http.StatusOK, res.StatusCode)
+	testEqual(t, "text/html; charset=utf-8", res.Header.Get("Content-Type"))
+	var record struct {
+		Status int `json:"status"`
+		Bytes  int `json:"bytes"`
+	}
+	testNil(t, json.NewDecoder(&buffer).Decode(&record))
+	testEqual(t, http.StatusOK, record.Status)
+	testEqual(t, 13, record.Bytes)
+}
+
+func TestRootHTTPHandlerRoutes(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		path   string
+		status int
+		body   string
+	}{
+		{path: "/health", status: http.StatusOK, body: `"version":"vroot"`},
+		{path: "/debug/vars", status: http.StatusOK, body: `"memstats"`},
+		{path: "/debug/pprof/goroutine?debug=1", status: http.StatusOK, body: "goroutine profile"},
+		{path: "/missing", status: http.StatusNotFound, body: "404 page not found"},
+	} {
+		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
+			var buffer bytes.Buffer
+			server := httptest.NewServer(newRootHTTPHandler(slog.New(slog.NewJSONHandler(&buffer, nil)), "vroot"))
+			t.Cleanup(server.Close)
+			server.Client().Timeout = 5 * time.Second
+			res, err := server.Client().Get(server.URL + tt.path)
+			testNil(t, err)
+			body, err := io.ReadAll(res.Body)
+			testNil(t, res.Body.Close())
+			testNil(t, err)
+			testEqual(t, tt.status, res.StatusCode)
+			testContains(t, tt.body, string(body))
+			server.Close()
+			var record struct {
+				Message string `json:"msg"`
+				Status  int    `json:"status"`
+				Bytes   int    `json:"bytes"`
+			}
+			decoder := json.NewDecoder(&buffer)
+			testNil(t, decoder.Decode(&record))
+			testEqual(t, "accessed", record.Message)
+			testEqual(t, tt.status, record.Status)
+			testEqual(t, len(body), record.Bytes)
+			testEqual(t, false, decoder.More())
+		})
+	}
+}
+
+func TestRequestOutcomesHijack(t *testing.T) {
+	t.Parallel()
+	for _, upgrade := range []bool{false, true} {
+		t.Run(strconv.FormatBool(upgrade), func(t *testing.T) {
+			t.Parallel()
+			var buffer bytes.Buffer
+			done := make(chan struct{})
+			handler := requestOutcomes(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if upgrade {
+					w.WriteHeader(http.StatusSwitchingProtocols)
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+				conn, rw, err := http.NewResponseController(w).Hijack()
+				if err != nil {
+					panic(err)
+				}
+				defer conn.Close() //nolint:errcheck
+				if !upgrade {
+					_, _ = rw.WriteString("HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\n\r\n")
+				}
+				if err := rw.Flush(); err != nil {
+					panic(err)
+				}
+			}), slog.New(slog.NewJSONHandler(&buffer, nil)))
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer close(done) // Server.Close does not wait for hijacked connections.
+				handler.ServeHTTP(w, r)
+			}))
+			t.Cleanup(server.Close)
+			server.Client().Timeout = 5 * time.Second
+			res, err := server.Client().Get(server.URL)
+			testNil(t, err)
+			testNil(t, res.Body.Close())
+			<-done
+			var record struct {
+				Status   int  `json:"status"`
+				Bytes    int  `json:"bytes"`
+				Hijacked bool `json:"hijacked"`
+			}
+			testNil(t, json.NewDecoder(&buffer).Decode(&record))
+			if upgrade {
+				testEqual(t, http.StatusSwitchingProtocols, res.StatusCode)
+				testEqual(t, http.StatusSwitchingProtocols, record.Status)
+			} else {
+				testEqual(t, http.StatusAccepted, res.StatusCode)
+				testEqual(t, 0, record.Status) // Raw connection writes are outside HTTP response accounting.
+			}
+			testEqual(t, 0, record.Bytes)
+			testEqual(t, true, record.Hijacked)
+		})
+	}
+}
+
+// Writer failures are exercised directly because a real connection cannot reliably
+// force a particular short write or flush error.
+func TestResponseRecorderWriteFailures(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name string
+		n    int
+		err  error
+	}{
+		{name: "short write", n: 2},
+		{name: "partial write with error", n: 2, err: io.ErrShortWrite},
+		{name: "failed write", err: io.ErrClosedPipe},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			recorder := responseRecorder{ResponseWriter: writeFailure{ResponseWriter: httptest.NewRecorder(), n: tt.n, err: tt.err}}
+			n, err := recorder.Write([]byte("hello"))
+			testEqual(t, tt.n, n)
+			testEqual(t, tt.err, err)
+			testEqual(t, tt.n, recorder.numBytes)
+			testEqual(t, http.StatusOK, recorder.status)
+		})
+	}
+}
+
+type writeFailure struct {
+	http.ResponseWriter
+	n   int
+	err error
+}
+
+func (w writeFailure) Write([]byte) (int, error) { return w.n, w.err }
+
+func TestResponseRecorderFlushFailures(t *testing.T) {
+	t.Parallel()
+	t.Run("unsupported flush does not commit", func(t *testing.T) {
+		t.Parallel()
+		underlying := httptest.NewRecorder()
+		recorder := responseRecorder{ResponseWriter: struct{ http.ResponseWriter }{underlying}}
+		err := http.NewResponseController(&recorder).Flush()
+		testEqual(t, true, errors.Is(err, http.ErrNotSupported))
+		recorder.WriteHeader(http.StatusCreated)
+		testEqual(t, http.StatusCreated, underlying.Code)
+		testEqual(t, http.StatusCreated, recorder.status)
+	})
+	t.Run("failed flush still commits", func(t *testing.T) {
+		t.Parallel()
+		underlying := httptest.NewRecorder()
+		recorder := responseRecorder{ResponseWriter: unwrapWriter{flushFailure{underlying}}}
+		err := http.NewResponseController(&recorder).Flush()
+		testEqual(t, io.ErrClosedPipe, err)
+		recorder.WriteHeader(http.StatusInternalServerError)
+		testEqual(t, http.StatusOK, underlying.Code)
+		testEqual(t, http.StatusOK, recorder.status)
+	})
+}
+
+type unwrapWriter struct{ http.ResponseWriter }
+
+func (w unwrapWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
+
+type flushFailure struct{ http.ResponseWriter }
+
+func (flushFailure) FlushError() error { return io.ErrClosedPipe }
 
 func testEqual[T comparable](tb testing.TB, want, got T) {
 	tb.Helper()

--- a/main_test.go
+++ b/main_test.go
@@ -195,22 +195,22 @@ func TestRequestOutcomes(t *testing.T) {
 			informational: []int{http.StatusEarlyHints},
 		},
 		{
-			name: "controller capabilities and direct flush",
+			name: "write deadline without connection takeover",
 			handler: func(w http.ResponseWriter, _ *http.Request) {
 				controller := http.NewResponseController(w)
-				if err := controller.SetReadDeadline(time.Now().Add(time.Minute)); err != nil {
-					panic(err)
-				}
 				if err := controller.SetWriteDeadline(time.Now().Add(time.Minute)); err != nil {
 					panic(err)
 				}
-				if err := controller.EnableFullDuplex(); err != nil {
-					panic(err)
+				conn, _, err := controller.Hijack()
+				if conn != nil {
+					_ = conn.Close()
 				}
-				w.(http.Flusher).Flush()
-				w.WriteHeader(http.StatusInternalServerError)
+				if !errors.Is(err, http.ErrNotSupported) {
+					panic("connection takeover should be unsupported")
+				}
+				w.WriteHeader(http.StatusCreated)
 			},
-			status: http.StatusOK,
+			status: http.StatusCreated,
 		},
 		{
 			name: "flush commits implicit status",
@@ -373,16 +373,18 @@ func TestRequestOutcomes(t *testing.T) {
 	}
 }
 
-func TestRequestOutcomesHTTP2Informational(t *testing.T) {
+func TestRequestOutcomesInformationalProtocols(t *testing.T) {
 	t.Parallel()
 	for _, tt := range []struct {
-		name    string
-		handler http.HandlerFunc
-		status  int
-		body    string
+		name       string
+		protoMajor int
+		handler    http.HandlerFunc
+		status     int
+		body       string
 	}{
 		{
-			name: "explicit final status",
+			name:       "HTTP2 explicit final status",
+			protoMajor: 2,
 			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusCreated)
 				_, _ = io.WriteString(w, "created")
@@ -391,15 +393,23 @@ func TestRequestOutcomesHTTP2Informational(t *testing.T) {
 			body:   "created",
 		},
 		{
-			name:    "implicit final status",
-			handler: func(http.ResponseWriter, *http.Request) {},
-			status:  http.StatusOK,
+			name:       "HTTP2 implicit final status",
+			protoMajor: 2,
+			handler:    func(http.ResponseWriter, *http.Request) {},
+			status:     http.StatusOK,
 		},
 		{
-			name:    "recovered panic",
-			handler: func(http.ResponseWriter, *http.Request) { panic("private panic details") },
-			status:  http.StatusInternalServerError,
-			body:    "internal server error\n",
+			name:       "HTTP2 recovered panic",
+			protoMajor: 2,
+			handler:    func(http.ResponseWriter, *http.Request) { panic("private panic details") },
+			status:     http.StatusInternalServerError,
+			body:       "internal server error\n",
+		},
+		{
+			name:       "HTTP1 switching protocols is final",
+			protoMajor: 1,
+			handler:    func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusInternalServerError) },
+			status:     http.StatusSwitchingProtocols,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -410,7 +420,7 @@ func TestRequestOutcomesHTTP2Informational(t *testing.T) {
 				tt.handler.ServeHTTP(w, r)
 			}), slog.New(slog.NewJSONHandler(&buffer, nil)))
 			server := httptest.NewUnstartedServer(handler)
-			server.EnableHTTP2 = true
+			server.EnableHTTP2 = tt.protoMajor == 2
 			server.StartTLS()
 			t.Cleanup(server.Close)
 			server.Client().Timeout = 5 * time.Second
@@ -426,10 +436,14 @@ func TestRequestOutcomesHTTP2Informational(t *testing.T) {
 			body, err := io.ReadAll(res.Body)
 			testNil(t, res.Body.Close())
 			testNil(t, err)
-			testEqual(t, 2, res.ProtoMajor)
+			testEqual(t, tt.protoMajor, res.ProtoMajor)
 			testEqual(t, tt.status, res.StatusCode)
 			testEqual(t, tt.body, string(body))
-			testEqual(t, true, slices.Equal([]int{http.StatusSwitchingProtocols}, informational))
+			if tt.protoMajor == 2 {
+				testEqual(t, true, slices.Equal([]int{http.StatusSwitchingProtocols}, informational))
+			} else {
+				testEqual(t, 0, len(informational))
+			}
 			server.Close()
 			decoder := json.NewDecoder(&buffer)
 			accesses := 0
@@ -515,59 +529,6 @@ func TestRootHTTPHandlerRoutes(t *testing.T) {
 	}
 }
 
-func TestRequestOutcomesHijack(t *testing.T) {
-	t.Parallel()
-	for _, upgrade := range []bool{false, true} {
-		t.Run(strconv.FormatBool(upgrade), func(t *testing.T) {
-			t.Parallel()
-			var buffer bytes.Buffer
-			done := make(chan struct{})
-			handler := requestOutcomes(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				if upgrade {
-					w.WriteHeader(http.StatusSwitchingProtocols)
-					w.WriteHeader(http.StatusInternalServerError)
-				}
-				conn, rw, err := http.NewResponseController(w).Hijack()
-				if err != nil {
-					panic(err)
-				}
-				defer conn.Close() //nolint:errcheck
-				if !upgrade {
-					_, _ = rw.WriteString("HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\n\r\n")
-				}
-				if err := rw.Flush(); err != nil {
-					panic(err)
-				}
-			}), slog.New(slog.NewJSONHandler(&buffer, nil)))
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				defer close(done) // Server.Close does not wait for hijacked connections.
-				handler.ServeHTTP(w, r)
-			}))
-			t.Cleanup(server.Close)
-			server.Client().Timeout = 5 * time.Second
-			res, err := server.Client().Get(server.URL)
-			testNil(t, err)
-			testNil(t, res.Body.Close())
-			<-done
-			var record struct {
-				Status   int  `json:"status"`
-				Bytes    int  `json:"bytes"`
-				Hijacked bool `json:"hijacked"`
-			}
-			testNil(t, json.NewDecoder(&buffer).Decode(&record))
-			if upgrade {
-				testEqual(t, http.StatusSwitchingProtocols, res.StatusCode)
-				testEqual(t, http.StatusSwitchingProtocols, record.Status)
-			} else {
-				testEqual(t, http.StatusAccepted, res.StatusCode)
-				testEqual(t, 0, record.Status) // Raw connection writes are outside HTTP response accounting.
-			}
-			testEqual(t, 0, record.Bytes)
-			testEqual(t, true, record.Hijacked)
-		})
-	}
-}
-
 // Writer failures are exercised directly because a real connection cannot reliably
 // force a particular short write or flush error.
 func TestResponseRecorderWriteFailures(t *testing.T) {
@@ -616,7 +577,7 @@ func TestResponseRecorderFlushFailures(t *testing.T) {
 	t.Run("failed flush still commits", func(t *testing.T) {
 		t.Parallel()
 		underlying := httptest.NewRecorder()
-		recorder := responseRecorder{ResponseWriter: unwrapWriter{flushFailure{underlying}}}
+		recorder := responseRecorder{ResponseWriter: flushFailure{underlying}}
 		err := http.NewResponseController(&recorder).Flush()
 		testEqual(t, io.ErrClosedPipe, err)
 		recorder.WriteHeader(http.StatusInternalServerError)
@@ -625,13 +586,12 @@ func TestResponseRecorderFlushFailures(t *testing.T) {
 	})
 }
 
-type unwrapWriter struct{ http.ResponseWriter }
-
-func (w unwrapWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
-
 type flushFailure struct{ http.ResponseWriter }
 
-func (flushFailure) FlushError() error { return io.ErrClosedPipe }
+func (w flushFailure) FlushError() error {
+	w.WriteHeader(http.StatusOK)
+	return io.ErrClosedPipe
+}
 
 func testEqual[T comparable](tb testing.TB, want, got T) {
 	tb.Helper()

--- a/main_test.go
+++ b/main_test.go
@@ -125,8 +125,8 @@ func TestRunPort(t *testing.T) {
 	}
 }
 
-// TestRequestOutcomes checks the response on the wire and its final access record.
-func TestRequestOutcomes(t *testing.T) {
+// TestAccessLogRecovery checks the response on the wire and its final access record.
+func TestAccessLogRecovery(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name          string
@@ -295,7 +295,7 @@ func TestRequestOutcomes(t *testing.T) {
 			t.Parallel()
 			var buffer bytes.Buffer
 			logger := slog.New(slog.NewJSONHandler(&buffer, nil))
-			server := httptest.NewServer(requestOutcomes(tt.handler, logger))
+			server := httptest.NewServer(accesslog(recovery(tt.handler, logger), logger))
 			t.Cleanup(server.Close)
 			server.Client().Timeout = 5 * time.Second
 			var informational []int
@@ -373,7 +373,7 @@ func TestRequestOutcomes(t *testing.T) {
 	}
 }
 
-func TestRequestOutcomesInformationalProtocols(t *testing.T) {
+func TestAccessLogRecoveryInformationalProtocols(t *testing.T) {
 	t.Parallel()
 	for _, tt := range []struct {
 		name       string
@@ -415,10 +415,12 @@ func TestRequestOutcomesInformationalProtocols(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var buffer bytes.Buffer
-			handler := requestOutcomes(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			logger := slog.New(slog.NewJSONHandler(&buffer, nil))
+			handler := recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusSwitchingProtocols)
 				tt.handler.ServeHTTP(w, r)
-			}), slog.New(slog.NewJSONHandler(&buffer, nil)))
+			}), logger)
+			handler = accesslog(handler, logger)
 			server := httptest.NewUnstartedServer(handler)
 			server.EnableHTTP2 = tt.protoMajor == 2
 			server.StartTLS()
@@ -467,12 +469,14 @@ func TestRequestOutcomesInformationalProtocols(t *testing.T) {
 	}
 }
 
-func TestRequestOutcomesImplicitHeaders(t *testing.T) {
+func TestAccessLogRecoveryImplicitHeaders(t *testing.T) {
 	t.Parallel()
 	var buffer bytes.Buffer
-	handler := requestOutcomes(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	logger := slog.New(slog.NewJSONHandler(&buffer, nil))
+	handler := recovery(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = io.WriteString(w, "<html></html>")
-	}), slog.New(slog.NewJSONHandler(&buffer, nil)))
+	}), logger)
+	handler = accesslog(handler, logger)
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
 	res := recorder.Result()


### PR DESCRIPTION
## Summary

Panics previously skipped access logging, and the response recorder could report a different status or byte count from the underlying writer. Place access logging outside recovery and defer its log so recovered panics and aborted requests get an access record. Keep the middleware separate, each with its own recorder.

Recovery sends a generic 500 before a final response is committed and aborts the connection or stream after a panic interrupts a committed response. Preserve `http.ErrAbortHandler`. Record the first accepted final status, implicit 200 responses, informational headers under HTTP/1 and HTTP/2, and bytes accepted by the writer.

Keep writer support limited to pprof's write-deadline extension. Explicit flushing, connection hijacking, and generic `Unwrap` forwarding remain unsupported. No new dependencies or lifecycle changes.

## Testing

- Real HTTP connections check client responses and access logs for recovered panics, buffered-response aborts, informational headers, duplicate final headers, empty responses, and health/debug routes.
- Focused writer tests cover short writes and partial failures.
- `make build test` passed with race detection and shuffled tests. Statement coverage is 83.3%.
- `golangci-lint run --allow-serial-runners` passed.
- `go run golang.org/x/tools/cmd/deadcode@latest -test ./...` passed.
